### PR TITLE
Fix local-provider model fetching and Lemonade :latest bug

### DIFF
--- a/server/src/routes/providers.js
+++ b/server/src/routes/providers.js
@@ -347,7 +347,7 @@ providersRouter.post("/:id/refresh-models", async (c) => {
       dbUtils.updateProvider(providerId, { baseUrl: normalizedBaseUrl });
     }
 
-    const models = await fetchModelsForProvider(provider.name, normalizedBaseUrl);
+    const models = await fetchModelsForProvider(provider.name, normalizedBaseUrl, provider.provider_type, provider.display_name);
 
     // Atomic model refresh
     const refreshModels = db.transaction(() => {
@@ -417,17 +417,22 @@ providersRouter.delete("/:id", async (c) => {
  */
 const MODEL_FETCHERS = {
   ollama: fetchOllamaModels,
-  lmstudio: fetchLMStudioModels,
+  lmstudio: (url) => fetchOpenAICompatibleModels(url, "LM Studio"),
+  "llama-cpp": (url) => fetchOpenAICompatibleModels(url, "llama.cpp server"),
+  llamafile: (url) => fetchOpenAICompatibleModels(url, "llamafile server"),
   replicate: () => Promise.resolve(getReplicateImageModels()),
 };
 
 /**
  * Fetch models for a provider using the appropriate fetcher
  */
-async function fetchModelsForProvider(providerName, baseUrl) {
+async function fetchModelsForProvider(providerName, baseUrl, providerType, displayName) {
   const fetcher = MODEL_FETCHERS[providerName];
   if (fetcher) {
     return await fetcher(baseUrl);
+  }
+  if (providerType === "openai-compatible") {
+    return await fetchOpenAICompatibleModels(baseUrl, displayName || providerName);
   }
   return await getModelsForProvider(providerName);
 }
@@ -454,22 +459,25 @@ async function fetchOllamaModels(baseUrl) {
       throw new Error("Invalid response from Ollama");
     }
 
-    return data.models.map((m) => ({
-      model_id: m.name,
-      display_name: m.name,
-      enabled: true,
-      metadata: {
-        context_window: 8192,
-        max_output_tokens: 2048,
-        supports_streaming: true,
-        supports_vision: m.name.includes("llava") || m.name.includes("vision"),
-        supports_tools: m.name.includes("qwen") || m.name.includes("llama3"),
-        input_price_per_1m: 0,
-        output_price_per_1m: 0,
-        size_bytes: m.size,
-        modified_at: m.modified_at,
-      },
-    }));
+    return data.models.map((m) => {
+      const modelId = m.name.replace(/:latest$/, "");
+      return {
+        model_id: modelId,
+        display_name: modelId,
+        enabled: true,
+        metadata: {
+          context_window: 8192,
+          max_output_tokens: 2048,
+          supports_streaming: true,
+          supports_vision: modelId.includes("llava") || modelId.includes("vision"),
+          supports_tools: modelId.includes("qwen") || modelId.includes("llama3"),
+          input_price_per_1m: 0,
+          output_price_per_1m: 0,
+          size_bytes: m.size,
+          modified_at: m.modified_at,
+        },
+      };
+    });
   } catch (error) {
     console.error("Failed to fetch Ollama models:", error.message);
     throw new Error(`Could not connect to Ollama at ${baseUrl}. Make sure Ollama is running.`);
@@ -477,30 +485,38 @@ async function fetchOllamaModels(baseUrl) {
 }
 
 /**
- * Fetch models from LM Studio
+ * Fetch models from an OpenAI-compatible /v1/models endpoint
+ * Used by lmstudio, llama-cpp, and llamafile providers
  */
-async function fetchLMStudioModels(baseUrl) {
+async function fetchOpenAICompatibleModels(
+  baseUrl,
+  displayProvider = "OpenAI-compatible server"
+) {
   if (!validateProviderUrl(baseUrl)) {
-    throw new Error("Invalid LM Studio base URL");
+    throw new Error(`Invalid ${displayProvider} base URL`);
   }
   try {
-    const modelsUrl = baseUrl.endsWith("/v1") ? `${baseUrl}/models` : `${baseUrl}/v1/models`;
+    const modelsUrl = baseUrl.endsWith("/v1")
+      ? `${baseUrl}/models`
+      : `${baseUrl}/v1/models`;
 
     const response = await fetch(modelsUrl, {
       signal: AbortSignal.timeout(TIMEOUTS.OLLAMA_FETCH),
     });
 
     if (!response.ok) {
-      throw new Error(`LM Studio API returned ${response.status}`);
+      throw new Error(`${displayProvider} API returned ${response.status}`);
     }
 
     const data = await response.json();
 
     if (!data.data || !Array.isArray(data.data)) {
-      throw new Error("Invalid response from LM Studio");
+      throw new Error(`Invalid response from ${displayProvider}`);
     }
 
-    const chatModels = data.data.filter((m) => !m.id.toLowerCase().includes("embedding"));
+    const chatModels = data.data.filter(
+      (m) => !m.id.toLowerCase().includes("embedding")
+    );
 
     return chatModels.map((m) => ({
       model_id: m.id,
@@ -511,17 +527,20 @@ async function fetchLMStudioModels(baseUrl) {
         max_output_tokens: 2048,
         supports_streaming: true,
         supports_vision:
-          m.id.toLowerCase().includes("vision") || m.id.toLowerCase().includes("llava"),
-        supports_tools: m.id.toLowerCase().includes("qwen") || m.id.toLowerCase().includes("llama"),
+          m.id.toLowerCase().includes("vision") ||
+          m.id.toLowerCase().includes("llava"),
+        supports_tools:
+          m.id.toLowerCase().includes("qwen") ||
+          m.id.toLowerCase().includes("llama"),
         input_price_per_1m: 0,
         output_price_per_1m: 0,
         owned_by: m.owned_by || "local",
       },
     }));
   } catch (error) {
-    console.error("Failed to fetch LM Studio models:", error.message);
+    console.error(`Failed to fetch ${displayProvider} models:`, error.message);
     throw new Error(
-      `Could not connect to LM Studio at ${baseUrl}. Make sure LM Studio is running.`
+      `Could not connect to ${displayProvider} at ${baseUrl}`
     );
   }
 }

--- a/server/src/routes/providers.js
+++ b/server/src/routes/providers.js
@@ -347,7 +347,12 @@ providersRouter.post("/:id/refresh-models", async (c) => {
       dbUtils.updateProvider(providerId, { baseUrl: normalizedBaseUrl });
     }
 
-    const models = await fetchModelsForProvider(provider.name, normalizedBaseUrl, provider.provider_type, provider.display_name);
+    const models = await fetchModelsForProvider(
+      provider.name,
+      normalizedBaseUrl,
+      provider.provider_type,
+      provider.display_name
+    );
 
     // Atomic model refresh
     const refreshModels = db.transaction(() => {
@@ -488,17 +493,12 @@ async function fetchOllamaModels(baseUrl) {
  * Fetch models from an OpenAI-compatible /v1/models endpoint
  * Used by lmstudio, llama-cpp, and llamafile providers
  */
-async function fetchOpenAICompatibleModels(
-  baseUrl,
-  displayProvider = "OpenAI-compatible server"
-) {
+async function fetchOpenAICompatibleModels(baseUrl, displayProvider = "OpenAI-compatible server") {
   if (!validateProviderUrl(baseUrl)) {
     throw new Error(`Invalid ${displayProvider} base URL`);
   }
   try {
-    const modelsUrl = baseUrl.endsWith("/v1")
-      ? `${baseUrl}/models`
-      : `${baseUrl}/v1/models`;
+    const modelsUrl = baseUrl.endsWith("/v1") ? `${baseUrl}/models` : `${baseUrl}/v1/models`;
 
     const response = await fetch(modelsUrl, {
       signal: AbortSignal.timeout(TIMEOUTS.OLLAMA_FETCH),
@@ -514,9 +514,7 @@ async function fetchOpenAICompatibleModels(
       throw new Error(`Invalid response from ${displayProvider}`);
     }
 
-    const chatModels = data.data.filter(
-      (m) => !m.id.toLowerCase().includes("embedding")
-    );
+    const chatModels = data.data.filter((m) => !m.id.toLowerCase().includes("embedding"));
 
     return chatModels.map((m) => ({
       model_id: m.id,
@@ -527,11 +525,8 @@ async function fetchOpenAICompatibleModels(
         max_output_tokens: 2048,
         supports_streaming: true,
         supports_vision:
-          m.id.toLowerCase().includes("vision") ||
-          m.id.toLowerCase().includes("llava"),
-        supports_tools:
-          m.id.toLowerCase().includes("qwen") ||
-          m.id.toLowerCase().includes("llama"),
+          m.id.toLowerCase().includes("vision") || m.id.toLowerCase().includes("llava"),
+        supports_tools: m.id.toLowerCase().includes("qwen") || m.id.toLowerCase().includes("llama"),
         input_price_per_1m: 0,
         output_price_per_1m: 0,
         owned_by: m.owned_by || "local",
@@ -539,8 +534,6 @@ async function fetchOpenAICompatibleModels(
     }));
   } catch (error) {
     console.error(`Failed to fetch ${displayProvider} models:`, error.message);
-    throw new Error(
-      `Could not connect to ${displayProvider} at ${baseUrl}`
-    );
+    throw new Error(`Could not connect to ${displayProvider} at ${baseUrl}`);
   }
 }

--- a/server/src/test/providers.test.js
+++ b/server/src/test/providers.test.js
@@ -341,10 +341,10 @@ describe("provider routes", () => {
       globalThis.fetch = async (input, init) => {
         const url = typeof input === "string" ? input : input.url;
         if (url && url.includes("/v1/models")) {
-          return new Response(
-            JSON.stringify({ data: models }),
-            { status: 200, headers: { "Content-Type": "application/json" } }
-          );
+          return new Response(JSON.stringify({ data: models }), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          });
         }
         return originalFetch(input, init);
       };
@@ -374,9 +374,7 @@ describe("provider routes", () => {
       let providerId;
 
       beforeAll(() => {
-        stubOpenAIModelsResponse([
-          { id: "llama-3.1-8b-instruct", owned_by: "local" },
-        ]);
+        stubOpenAIModelsResponse([{ id: "llama-3.1-8b-instruct", owned_by: "local" }]);
       });
 
       afterAll(() => {
@@ -594,10 +592,10 @@ describe("provider routes", () => {
         globalThis.fetch = async (input, init) => {
           const url = typeof input === "string" ? input : input.url;
           if (url && url.includes("/v1/models")) {
-            return new Response(
-              JSON.stringify({ foo: "bar" }),
-              { status: 200, headers: { "Content-Type": "application/json" } }
-            );
+            return new Response(JSON.stringify({ foo: "bar" }), {
+              status: 200,
+              headers: { "Content-Type": "application/json" },
+            });
           }
           return originalFetch(input, init);
         };
@@ -654,10 +652,7 @@ describe("provider routes", () => {
         if (url && url.endsWith("/api/tags")) {
           return new Response(
             JSON.stringify({
-              models: [
-                { name: "qwen3.5-4b-FLM:latest" },
-                { name: "llama3.2:q4_k_m" },
-              ],
+              models: [{ name: "qwen3.5-4b-FLM:latest" }, { name: "llama3.2:q4_k_m" }],
             }),
             { status: 200, headers: { "Content-Type": "application/json" } }
           );

--- a/server/src/test/providers.test.js
+++ b/server/src/test/providers.test.js
@@ -1,4 +1,4 @@
-import { describe, test, expect, beforeAll } from "bun:test";
+import { describe, test, expect, beforeAll, afterAll } from "bun:test";
 import {
   createTestApp,
   resetDatabase,
@@ -324,6 +324,379 @@ describe("provider routes", () => {
         (l) => l.action === "api_key_changed" && String(l.target_id) === String(providerId)
       );
       expect(keyChangeEntry).toBeDefined();
+    });
+  });
+
+  // =============================================
+  // OpenAI-compatible model fetcher (llama-cpp / llamafile)
+  // =============================================
+  describe("OpenAI-compatible model fetcher", () => {
+    let originalFetch;
+
+    beforeAll(() => {
+      originalFetch = globalThis.fetch;
+    });
+
+    function stubOpenAIModelsResponse(models) {
+      globalThis.fetch = async (input, init) => {
+        const url = typeof input === "string" ? input : input.url;
+        if (url && url.includes("/v1/models")) {
+          return new Response(
+            JSON.stringify({ data: models }),
+            { status: 200, headers: { "Content-Type": "application/json" } }
+          );
+        }
+        return originalFetch(input, init);
+      };
+    }
+
+    function restoreFetch() {
+      globalThis.fetch = originalFetch;
+    }
+
+    async function createTestProvider({ name, displayName = "llama.cpp", baseUrl }) {
+      const res = await makeRequest(app, "POST", "/api/admin/providers", {
+        body: {
+          name,
+          displayName,
+          providerType: "openai-compatible",
+          baseUrl,
+          apiKey: "sk-test",
+        },
+        cookie: adminCookie,
+      });
+      const data = await res.json();
+      return data.provider.id;
+    }
+
+    // --- Cycle 1: llama-cpp refresh populates models ---
+    describe("llama-cpp provider", () => {
+      let providerId;
+
+      beforeAll(() => {
+        stubOpenAIModelsResponse([
+          { id: "llama-3.1-8b-instruct", owned_by: "local" },
+        ]);
+      });
+
+      afterAll(() => {
+        restoreFetch();
+      });
+
+      test("refresh returns model_count > 0", async () => {
+        // Create the provider
+        const createRes = await makeRequest(app, "POST", "/api/admin/providers", {
+          body: {
+            name: "llama-cpp",
+            displayName: "llama.cpp",
+            providerType: "openai-compatible",
+            baseUrl: "http://localhost:8080",
+            apiKey: "sk-test",
+          },
+          cookie: adminCookie,
+        });
+        expect(createRes.status).toBe(201);
+        const createData = await createRes.json();
+        providerId = createData.provider.id;
+
+        // Refresh models
+        const refreshRes = await makeRequest(
+          app,
+          "POST",
+          `/api/admin/providers/${providerId}/refresh-models`,
+          { cookie: adminCookie }
+        );
+        expect(refreshRes.status).toBe(200);
+        const refreshData = await refreshRes.json();
+        expect(refreshData.model_count).toBeGreaterThan(0);
+        expect(refreshData.model_count).toBe(1);
+      });
+    });
+
+    // --- Cycle 2: llamafile registered under distinct key ---
+    describe("llamafile provider", () => {
+      let llamafileProviderId;
+
+      beforeAll(() => {
+        stubOpenAIModelsResponse([
+          { id: "llama-3.2-3b-instruct", owned_by: "local" },
+          { id: "phi-3-mini", owned_by: "local" },
+        ]);
+      });
+
+      afterAll(() => {
+        restoreFetch();
+      });
+
+      test("refresh returns model_count > 0 with distinct key", async () => {
+        const createRes = await makeRequest(app, "POST", "/api/admin/providers", {
+          body: {
+            name: "llamafile",
+            displayName: "Llamafile",
+            providerType: "openai-compatible",
+            baseUrl: "http://localhost:8081",
+            apiKey: "sk-test",
+          },
+          cookie: adminCookie,
+        });
+        expect(createRes.status).toBe(201);
+        const createData = await createRes.json();
+        llamafileProviderId = createData.provider.id;
+
+        const refreshRes = await makeRequest(
+          app,
+          "POST",
+          `/api/admin/providers/${llamafileProviderId}/refresh-models`,
+          { cookie: adminCookie }
+        );
+        expect(refreshRes.status).toBe(200);
+        const refreshData = await refreshRes.json();
+        expect(refreshData.model_count).toBe(2);
+      });
+    });
+
+    // --- Cycle 3: URL normalization — baseUrl ending in /v1 ---
+    describe("URL normalization", () => {
+      let capturedUrl;
+      let llamaCppUrlnormId;
+
+      beforeAll(async () => {
+        llamaCppUrlnormId = await createTestProvider({
+          name: "llama-cpp-urlnorm",
+          baseUrl: "http://localhost:8082",
+        });
+
+        globalThis.fetch = async (input, init) => {
+          const url = typeof input === "string" ? input : input.url;
+          capturedUrl = url;
+          if (url && url.includes("/v1/models")) {
+            return new Response(
+              JSON.stringify({ data: [{ id: "test-model", owned_by: "local" }] }),
+              { status: 200, headers: { "Content-Type": "application/json" } }
+            );
+          }
+          return originalFetch(input, init);
+        };
+      });
+
+      afterAll(() => {
+        restoreFetch();
+      });
+
+      test("baseUrl ending in /v1 does not double-append /v1/models", async () => {
+        const updateRes = await makeRequest(
+          app,
+          "PUT",
+          `/api/admin/providers/${llamaCppUrlnormId}`,
+          {
+            body: { baseUrl: "http://localhost:8082/v1" },
+            cookie: adminCookie,
+          }
+        );
+        expect(updateRes.status).toBe(200);
+
+        const refreshRes = await makeRequest(
+          app,
+          "POST",
+          `/api/admin/providers/${llamaCppUrlnormId}/refresh-models`,
+          { cookie: adminCookie }
+        );
+        expect(refreshRes.status).toBe(200);
+        expect(capturedUrl).toBe("http://localhost:8082/v1/models");
+        expect(capturedUrl).not.toContain("/v1/v1/models");
+      });
+    });
+
+    // --- Cycle 4: embedding filter ---
+    describe("embedding filter", () => {
+      let embedProviderId;
+
+      beforeAll(async () => {
+        stubOpenAIModelsResponse([
+          { id: "llama-3.1-8b-instruct", owned_by: "local" },
+          { id: "nomic-embed-text-v1", owned_by: "local" },
+          { id: "text-embedding-3-small", owned_by: "local" },
+        ]);
+
+        embedProviderId = await createTestProvider({
+          name: "llama-cpp-embed",
+          baseUrl: "http://localhost:8083",
+        });
+      });
+
+      afterAll(() => {
+        restoreFetch();
+      });
+
+      test("excludes embedding models from results", async () => {
+        const refreshRes = await makeRequest(
+          app,
+          "POST",
+          `/api/admin/providers/${embedProviderId}/refresh-models`,
+          { cookie: adminCookie }
+        );
+        expect(refreshRes.status).toBe(200);
+        const refreshData = await refreshRes.json();
+        // 3 models: 1 chat + 1 embed (not "embedding") + 1 embedding → 2 pass filter
+        expect(refreshData.model_count).toBe(2);
+      });
+    });
+
+    // --- Cycle 5: unreachable URL surfaces display name ---
+    describe("error messages", () => {
+      let originalConsoleError;
+      let errorCalls;
+      let errorProviderId;
+
+      beforeAll(async () => {
+        errorCalls = [];
+        originalConsoleError = console.error;
+        console.error = (...args) => {
+          errorCalls.push(args);
+        };
+
+        errorProviderId = await createTestProvider({
+          name: "llama-cpp-error",
+          baseUrl: "http://localhost:8084",
+        });
+
+        globalThis.fetch = async () => {
+          throw new Error("network error");
+        };
+      });
+
+      afterAll(() => {
+        console.error = originalConsoleError;
+        restoreFetch();
+      });
+
+      test("unreachable llama-cpp URL mentions display name in error", async () => {
+        const refreshRes = await makeRequest(
+          app,
+          "POST",
+          `/api/admin/providers/${errorProviderId}/refresh-models`,
+          { cookie: adminCookie }
+        );
+        expect(refreshRes.status).toBe(500);
+
+        const relevantCall = errorCalls.find((call) =>
+          call.some((arg) => typeof arg === "string" && arg.includes("llama.cpp"))
+        );
+        expect(relevantCall).toBeDefined();
+      });
+    });
+
+    // --- Cycle 6: invalid response shape ---
+    describe("invalid response shape", () => {
+      let invalidProviderId;
+
+      beforeAll(async () => {
+        globalThis.fetch = async (input, init) => {
+          const url = typeof input === "string" ? input : input.url;
+          if (url && url.includes("/v1/models")) {
+            return new Response(
+              JSON.stringify({ foo: "bar" }),
+              { status: 200, headers: { "Content-Type": "application/json" } }
+            );
+          }
+          return originalFetch(input, init);
+        };
+
+        invalidProviderId = await createTestProvider({
+          name: "llama-cpp-invalid",
+          baseUrl: "http://localhost:8085",
+        });
+      });
+
+      afterAll(() => {
+        restoreFetch();
+      });
+
+      test("non-array response returns 500", async () => {
+        const refreshRes = await makeRequest(
+          app,
+          "POST",
+          `/api/admin/providers/${invalidProviderId}/refresh-models`,
+          { cookie: adminCookie }
+        );
+        expect(refreshRes.status).toBe(500);
+      });
+    });
+
+    // --- Cycle 7: SSRF guard on llama-cpp base URL ---
+    describe("SSRF guard", () => {
+      test("metadata service URL in llama-cpp baseUrl returns 400", async () => {
+        const res = await makeRequest(app, "POST", "/api/admin/providers", {
+          body: {
+            name: "llama-cpp-ssrf",
+            displayName: "llama.cpp SSRF",
+            providerType: "openai-compatible",
+            baseUrl: "http://169.254.169.254",
+            apiKey: "sk-test",
+          },
+          cookie: adminCookie,
+        });
+        expect(res.status).toBe(400);
+        const data = await res.json();
+        expect(data.error).toContain("Invalid base URL");
+      });
+    });
+  });
+
+  describe("Ollama model fetcher :latest normalization", () => {
+    let originalFetch;
+    let providerId;
+
+    beforeAll(async () => {
+      originalFetch = globalThis.fetch;
+      globalThis.fetch = async (input, init) => {
+        const url = typeof input === "string" ? input : input.url;
+        if (url && url.endsWith("/api/tags")) {
+          return new Response(
+            JSON.stringify({
+              models: [
+                { name: "qwen3.5-4b-FLM:latest" },
+                { name: "llama3.2:q4_k_m" },
+              ],
+            }),
+            { status: 200, headers: { "Content-Type": "application/json" } }
+          );
+        }
+        return originalFetch(input, init);
+      };
+
+      const createRes = await makeRequest(app, "POST", "/api/admin/providers", {
+        body: {
+          name: "ollama",
+          displayName: "ollama",
+          providerType: "openai-compatible",
+          baseUrl: "http://localhost:11434",
+          apiKey: "sk-test",
+        },
+        cookie: adminCookie,
+      });
+      providerId = (await createRes.json()).provider.id;
+    });
+
+    afterAll(() => {
+      globalThis.fetch = originalFetch;
+    });
+
+    test("strips trailing :latest, preserves other tags", async () => {
+      const refreshRes = await makeRequest(
+        app,
+        "POST",
+        `/api/admin/providers/${providerId}/refresh-models`,
+        { cookie: adminCookie }
+      );
+      expect(refreshRes.status).toBe(200);
+      expect((await refreshRes.json()).model_count).toBe(2);
+
+      const models = dbUtils.getModelsByProvider(providerId);
+      const ids = models.map((m) => m.model_id).sort();
+      const displayNames = models.map((m) => m.display_name).sort();
+      expect(ids).toEqual(["llama3.2:q4_k_m", "qwen3.5-4b-FLM"]);
+      expect(displayNames).toEqual(["llama3.2:q4_k_m", "qwen3.5-4b-FLM"]);
     });
   });
 });


### PR DESCRIPTION
## Summary

Two bugs, one branch.

**Local providers weren't loading models.** `llama-cpp` and `llamafile` were registered but had no fetcher wired up, so clicking Refresh did nothing. Added a shared OpenAI-compat fetcher that handles all three of them (plus LM Studio, which was running a near-identical copy of the same code).

**Lemonade chat was broken.** Closes #12. Ollama's `/api/tags` endpoint returns model names with a `:latest` suffix. We stored those names verbatim and sent them back on chat, which Lemonade's OpenAI endpoint rejects. The fix strips trailing `:latest` on the way in. Other tags like `:q4_k_m` pass through untouched, so real Ollama users with specific quantizations keep working.

Two smaller things came along for the ride. Model metadata now stores `owned_by: "local"` instead of the display name, matching how LM Studio already did it. And the URL validation guard moved out of the try/catch so a bad URL no longer masquerades as a connection error.

## What changed

- One shared fetcher for llama-cpp, llamafile, LM Studio, and any other OpenAI-compatible provider
- `:latest` stripped from Ollama model IDs at fetch time
- `owned_by` metadata normalized to `"local"` for local providers
- Invalid URL errors now say what they mean

## For existing installs

Hit Refresh in Admin → Connections after updating. The refresh replaces all models atomically — no migration, no manual DB work.

## Test plan

- [x] `bun test` — 260 pass, 0 fail
- [x] New tests cover URL normalization, embedding filter, error messaging, invalid response shape, SSRF guard, and `:latest` stripping
- [x] Manual: connect to a real Lemonade server and send a chat
- [x] Manual: connect to a real llama-cpp server and refresh models
