### PR TITLE
Fix 13 data-flow review findings

### DIFF
--- a/frontend/src/hooks/useChatStream.js
+++ b/frontend/src/hooks/useChatStream.js
@@ -22,6 +22,7 @@ function formatMessagesForTransport(messages) {
     id: message.id ?? crypto.randomUUID(),
     role: message.role,
     content: (message.parts ?? []).map((part) => (part.type === "text" ? part.text : "")).join(""),
+    fileIds: message.fileIds || [],
   }));
 }
 
@@ -62,6 +63,7 @@ export function useChatStream({
             id: msg.id,
             role: msg.role,
             parts: [{ type: "text", text: msg.content ?? "" }],
+            fileIds: msg.fileIds || [],
           }));
 
           // Merge persisted history with new messages from SDK

--- a/frontend/src/hooks/useChatsQuery.js
+++ b/frontend/src/hooks/useChatsQuery.js
@@ -2,6 +2,8 @@ import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { chatsClient } from "@/lib/chatsClient";
 import { useAuthState } from "@/state/useAuthState";
 import { getMessageTimestamp } from "@/lib/messageUtils";
+import { toCanonicalMessage } from "@/lib/messageShape.js";
+import { sortChatsLikeServer } from "@/lib/chatSort.js";
 import { chatKeys, folderKeys } from "./queryKeys";
 
 // Re-export for backward compatibility
@@ -33,22 +35,7 @@ export function useMessagesQuery(chatId) {
   return useQuery({
     queryKey: chatKeys.messages(userId, chatId),
     queryFn: () => chatsClient.getMessages(chatId),
-    select: (messages) =>
-      messages.map((msg) => {
-        const parts = [{ type: "text", text: msg.content }];
-        if (msg.metadata?.toolParts) {
-          parts.push(...msg.metadata.toolParts);
-        }
-        return {
-          id: msg.id,
-          role: msg.role,
-          content: msg.content,
-          parts,
-          fileIds: msg.fileIds || [],
-          model: msg.model || null,
-          createdAt: getMessageTimestamp(msg),
-        };
-      }),
+    select: (messages) => messages.map(toCanonicalMessage),
     enabled: userId !== null && !!chatId,
   });
 }
@@ -62,7 +49,7 @@ export function useCreateChatMutation() {
     onSuccess: (newChat, { folderId } = {}) => {
       queryClient.setQueryData(chatKeys.list(userId), (old) => {
         if (!old) return [newChat];
-        return [newChat, ...old];
+        return sortChatsLikeServer([newChat, ...old]);
       });
       // Invalidate folder chats if created in a folder
       if (folderId) {
@@ -102,6 +89,9 @@ export function useDeleteChatMutation() {
       queryClient.removeQueries({ queryKey: chatKeys.detail(userId, chatId) });
       queryClient.removeQueries({ queryKey: chatKeys.messages(userId, chatId) });
     },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: ["folders"] });
+    },
   });
 }
 
@@ -124,14 +114,15 @@ export function useCreateMessageMutation() {
       // Create optimistic message with stable id/createdAt
       const optimisticId = message.id || `temp-${crypto.randomUUID()}`;
       const optimisticCreatedAt = getMessageTimestamp(message);
-      const optimisticMessage = {
+      const optimisticMessage = toCanonicalMessage({
         id: optimisticId,
         role: message.role,
         content: message.content,
         fileIds: message.fileIds || [],
         model: message.model || null,
         createdAt: optimisticCreatedAt,
-      };
+        metadata: message.metadata,
+      });
 
       if (message.role === "user") {
         // Insert optimistic message into cache
@@ -145,27 +136,29 @@ export function useCreateMessageMutation() {
       queryClient.setQueryData(chatKeys.list(userId), (old) => {
         if (!old) return old;
         const now = Date.now();
-        return old
-          .map((chat) => (chat.id === chatId ? { ...chat, updatedAt: now } : chat))
-          .sort((a, b) => b.updatedAt - a.updatedAt);
+        const updated = old.map((chat) =>
+          chat.id === chatId ? { ...chat, updatedAt: now } : chat
+        );
+        return sortChatsLikeServer(updated);
       });
 
       return { previousMessages, previousChats, optimisticMessage };
     },
 
     onSuccess: (savedMessage, { chatId }, context) => {
+      const canonical = toCanonicalMessage(savedMessage);
       // Replace optimistic message with saved one from server (by id)
       queryClient.setQueryData(chatKeys.messages(userId, chatId), (old) => {
-        if (!old) return [savedMessage];
+        if (!old) return [canonical];
         let found = false;
         const mapped = old.map((msg) => {
-          if (msg.id === savedMessage.id || msg.id === context?.optimisticMessage?.id) {
+          if (msg.id === canonical.id || msg.id === context?.optimisticMessage?.id) {
             found = true;
-            return savedMessage;
+            return canonical;
           }
           return msg;
         });
-        return found ? mapped : [...mapped, savedMessage];
+        return found ? mapped : [...mapped, canonical];
       });
     },
 

--- a/frontend/src/hooks/useFolders.js
+++ b/frontend/src/hooks/useFolders.js
@@ -17,7 +17,6 @@ export function useFolders() {
   const { data, isLoading, error } = useQuery({
     queryKey: folderKeys.list(userId),
     queryFn: () => apiFetch("/api/folders"),
-    select: (data) => data.folders || [],
     enabled: userId !== null,
   });
 
@@ -143,7 +142,7 @@ export function useFolders() {
   });
 
   return {
-    folders: data || [],
+    folders: data?.folders ?? [],
     isLoading,
     error,
     createFolder: createMutation.mutateAsync,

--- a/frontend/src/lib/chatSort.js
+++ b/frontend/src/lib/chatSort.js
@@ -1,0 +1,11 @@
+export function sortChatsLikeServer(chats) {
+  return [...chats].sort((a, b) => {
+    const aPinned = a.pinnedAt ? 0 : 1;
+    const bPinned = b.pinnedAt ? 0 : 1;
+    if (aPinned !== bPinned) return aPinned - bPinned;
+    if (a.pinnedAt && b.pinnedAt && a.pinnedAt !== b.pinnedAt) {
+      return b.pinnedAt - a.pinnedAt;
+    }
+    return b.updatedAt - a.updatedAt;
+  });
+}

--- a/frontend/src/lib/messageShape.js
+++ b/frontend/src/lib/messageShape.js
@@ -1,0 +1,15 @@
+import { getMessageTimestamp } from "./messageUtils.js";
+
+export function toCanonicalMessage(msg) {
+  const parts = [{ type: "text", text: msg.content ?? "" }];
+  if (msg.metadata?.toolParts) parts.push(...msg.metadata.toolParts);
+  return {
+    id: msg.id,
+    role: msg.role,
+    content: msg.content ?? "",
+    parts,
+    fileIds: msg.fileIds || [],
+    model: msg.model || null,
+    createdAt: getMessageTimestamp(msg),
+  };
+}

--- a/packages/shared/src/constants/config.js
+++ b/packages/shared/src/constants/config.js
@@ -43,6 +43,9 @@ export const COMPLETION_CONSTANTS = {
   MAX_TOKENS: 4096,
 };
 
+/** Maximum facts persisted per memory extraction turn */
+export const MEMORY_EXTRACTION_MAX_FACTS_PER_TURN = 10;
+
 /** Web Search Constants */
 export const WEB_SEARCH_CONSTANTS = {
   MAX_RESULTS: 5,

--- a/server/src/lib/db.js
+++ b/server/src/lib/db.js
@@ -643,34 +643,36 @@ export const dbUtils = {
       isDefault: "is_default",
     };
 
-    if (updates.isDefault) {
-      db.prepare("UPDATE models SET is_default = 0").run();
-    }
-
-    const { fields, values } = buildUpdateFields(updates, fieldMap);
-
-    if (updates.enabled !== undefined) {
-      const enabledIndex = fields.findIndex((f) => f.includes("enabled"));
-      if (enabledIndex >= 0) {
-        values[enabledIndex] = updates.enabled ? 1 : 0;
+    db.transaction(() => {
+      if (updates.isDefault) {
+        db.prepare("UPDATE models SET is_default = 0").run();
       }
-    }
 
-    if (updates.isDefault !== undefined) {
-      const defaultIndex = fields.findIndex((f) => f.includes("is_default"));
-      if (defaultIndex >= 0) {
-        values[defaultIndex] = updates.isDefault ? 1 : 0;
+      const { fields, values } = buildUpdateFields(updates, fieldMap);
+
+      if (updates.enabled !== undefined) {
+        const enabledIndex = fields.findIndex((f) => f.includes("enabled"));
+        if (enabledIndex >= 0) {
+          values[enabledIndex] = updates.enabled ? 1 : 0;
+        }
       }
-    }
 
-    if (fields.length === 0) return;
+      if (updates.isDefault !== undefined) {
+        const defaultIndex = fields.findIndex((f) => f.includes("is_default"));
+        if (defaultIndex >= 0) {
+          values[defaultIndex] = updates.isDefault ? 1 : 0;
+        }
+      }
 
-    fields.push("updated_at = ?");
-    values.push(Date.now());
-    values.push(modelId);
+      if (fields.length === 0) return;
 
-    const stmt = db.prepare(`UPDATE models SET ${fields.join(", ")} WHERE id = ?`);
-    stmt.run(...values);
+      fields.push("updated_at = ?");
+      values.push(Date.now());
+      values.push(modelId);
+
+      const stmt = db.prepare(`UPDATE models SET ${fields.join(", ")} WHERE id = ?`);
+      stmt.run(...values);
+    })();
   },
 
   /**

--- a/server/src/lib/memory.js
+++ b/server/src/lib/memory.js
@@ -1,4 +1,5 @@
 import { wrapLanguageModel, generateText } from "ai";
+import { MEMORY_EXTRACTION_MAX_FACTS_PER_TURN } from "@faster-chat/shared";
 import { getModelInstance } from "./providerFactory.js";
 
 export const MEMORY_EXTRACTION_PROMPT = `Extract factual information about the user from this conversation. Return ONLY a JSON array of short factual strings. Focus on: preferences, personal details, projects, technical stack, communication style, and stated goals. If nothing worth remembering, return an empty array []. Do not include conversation-specific details that won't be relevant in future conversations. Examples: ["prefers Python over JavaScript", "works on a project called FasterChat", "uses Arch Linux", "name is Mike"]. Return ONLY the JSON array, no other text.`;
@@ -81,8 +82,9 @@ export async function extractMemories({
 
     if (Array.isArray(facts) && facts.length > 0) {
       const validFacts = facts.filter((f) => typeof f === "string" && f.trim().length > 0);
-      if (validFacts.length > 0) {
-        dbUtils.upsertMemories(userId, validFacts, chatId);
+      const cappedFacts = validFacts.slice(0, MEMORY_EXTRACTION_MAX_FACTS_PER_TURN);
+      if (cappedFacts.length > 0) {
+        dbUtils.upsertMemories(userId, cappedFacts, chatId);
       }
     }
   } catch (err) {

--- a/server/src/routes/chats.js
+++ b/server/src/routes/chats.js
@@ -65,6 +65,7 @@ chatsRouter.get("/", async (c) => {
       chats: chats.map((chat) => ({
         id: chat.id,
         title: chat.title,
+        folderId: chat.folder_id,
         pinnedAt: chat.pinned_at,
         archivedAt: chat.archived_at,
         createdAt: chat.created_at,
@@ -105,7 +106,7 @@ chatsRouter.post("/", async (c) => {
       {
         id: chat.id,
         title: chat.title,
-        folder_id: chat.folder_id,
+        folderId: chat.folder_id,
         createdAt: chat.created_at,
         updatedAt: chat.updated_at,
       },
@@ -358,17 +359,26 @@ chatsRouter.post("/:chatId/messages", async (c) => {
       validated.metadata || null
     );
 
-    const isFirstMessage = dbUtils.getMessageCountByChat(chatId) === 1;
-    if (isFirstMessage && validated.role === "user") {
-      let title;
-      if (validated.model) {
-        title = await generateChatTitle(validated.content, validated.model);
+    if (validated.role === "user") {
+      const isFirstMessage = dbUtils.getMessageCountByChat(chatId) === 1;
+      if (isFirstMessage) {
+        let title = truncateToTitle(validated.content); // always computed
+        if (validated.model) {
+          try {
+            const aiTitle = await generateChatTitle(validated.content, validated.model);
+            if (aiTitle && aiTitle.trim()) title = aiTitle;
+          } catch (err) {
+            console.warn("AI title upgrade failed, keeping fallback:", err.message);
+          }
+        }
+        try {
+          dbUtils.updateChatTitle(chatId, title);
+        } catch (err) {
+          console.error("updateChatTitle failed:", err);
+        }
       } else {
-        title = truncateToTitle(validated.content);
+        dbUtils.updateChatTimestamp(chatId);
       }
-      dbUtils.updateChatTitle(chatId, title);
-    } else {
-      dbUtils.updateChatTimestamp(chatId);
     }
 
     return c.json(
@@ -433,6 +443,7 @@ const CompletionRequestSchema = z.object({
       id: z.string(),
       role: z.enum(["user", "assistant", "system"]),
       content: z.string(),
+      fileIds: z.array(z.string()).optional(),
     })
   ),
   fileIds: z.array(z.string()).optional(),
@@ -561,7 +572,7 @@ function applyCacheControl(messages, modelId) {
 /**
  * Create multimodal content array with text and file attachments
  */
-async function createMultimodalContent(message, fileIds, userId) {
+export async function createMultimodalContent(message, fileIds, userId) {
   const content = [];
 
   if (message.content.trim()) {
@@ -574,12 +585,8 @@ async function createMultimodalContent(message, fileIds, userId) {
   }
 
   for (const file of files) {
-    try {
-      const contentPart = await fileToContentPart(file);
-      content.push(contentPart);
-    } catch (error) {
-      console.error(`Failed to process file ${file.id}:`, error);
-    }
+    const contentPart = await fileToContentPart(file);
+    content.push(contentPart);
   }
 
   return content;
@@ -595,11 +602,13 @@ async function convertToModelMessages(messages, systemPrompt, fileIds = [], user
     const msg = messages[i];
     if (msg.role === "system") continue;
 
-    const isLastUserWithFiles =
-      i === messages.length - 1 && msg.role === "user" && fileIds.length > 0;
+    const isLastUser = i === messages.length - 1 && msg.role === "user";
+    // top-level fileIds is the legacy per-last-message path; messages[].fileIds takes precedence
+    const msgFileIds =
+      msg.fileIds && msg.fileIds.length > 0 ? msg.fileIds : isLastUser ? fileIds : [];
 
-    if (isLastUserWithFiles) {
-      const content = await createMultimodalContent(msg, fileIds, userId);
+    if (msg.role === "user" && msgFileIds.length > 0) {
+      const content = await createMultimodalContent(msg, msgFileIds, userId);
       result.push({ role: msg.role, content });
     } else {
       result.push({ role: msg.role, content: msg.content });

--- a/server/src/routes/models.js
+++ b/server/src/routes/models.js
@@ -12,8 +12,8 @@ const debug = process.env.NODE_ENV !== "production";
 export const modelsRouter = new Hono();
 
 // Admin-only routes
-const adminRouter = new Hono();
-adminRouter.use("*", ensureSession, requireRole("admin"));
+const adminModelsRouter = new Hono();
+adminModelsRouter.use("*", ensureSession, requireRole("admin"));
 
 // Public route (for users to see available models)
 const publicRouter = new Hono();
@@ -60,7 +60,7 @@ publicRouter.get("/", async (c) => {
  * GET /api/admin/models
  * List all models (admin only)
  */
-adminRouter.get("/", async (c) => {
+adminModelsRouter.get("/", async (c) => {
   try {
     const type = c.req.query("type");
     const models = type ? dbUtils.getModelsByType(type) : dbUtils.getAllModels();
@@ -93,7 +93,7 @@ adminRouter.get("/", async (c) => {
  * GET /api/admin/models/:id
  * Get model details
  */
-adminRouter.get("/:id", async (c) => {
+adminModelsRouter.get("/:id", async (c) => {
   try {
     const modelId = parseInt(c.req.param("id"), 10);
 
@@ -133,7 +133,7 @@ adminRouter.get("/:id", async (c) => {
  * PUT /api/admin/models/:id
  * Update model
  */
-adminRouter.put("/:id", async (c) => {
+adminModelsRouter.put("/:id", async (c) => {
   try {
     const modelId = parseInt(c.req.param("id"), 10);
     const body = await c.req.json();
@@ -160,7 +160,7 @@ adminRouter.put("/:id", async (c) => {
  * PUT /api/admin/models/:id/default
  * Set model as default
  */
-adminRouter.put("/:id/default", async (c) => {
+adminModelsRouter.put("/:id/default", async (c) => {
   try {
     const modelId = parseInt(c.req.param("id"), 10);
 
@@ -182,7 +182,7 @@ adminRouter.put("/:id/default", async (c) => {
  * DELETE /api/admin/models/:id
  * Delete model
  */
-adminRouter.delete("/:id", async (c) => {
+adminModelsRouter.delete("/:id", async (c) => {
   try {
     const modelId = parseInt(c.req.param("id"), 10);
 
@@ -205,173 +205,177 @@ adminRouter.delete("/:id", async (c) => {
  * Pull an Ollama model from the Ollama registry
  * Streams progress via Server-Sent Events
  */
-adminRouter.post("/ollama/pull", createRateLimiter(ENDPOINT_RATE_LIMITS.OLLAMA_PULL), async (c) => {
-  try {
-    const body = await c.req.json();
-    const { providerId, modelName } = z
-      .object({
-        providerId: z.number().int().positive(),
-        modelName: z.string().min(1),
-      })
-      .parse(body);
+adminModelsRouter.post(
+  "/ollama/pull",
+  createRateLimiter(ENDPOINT_RATE_LIMITS.OLLAMA_PULL),
+  async (c) => {
+    try {
+      const body = await c.req.json();
+      const { providerId, modelName } = z
+        .object({
+          providerId: z.number().int().positive(),
+          modelName: z.string().min(1),
+        })
+        .parse(body);
 
-    const provider = dbUtils.getProviderById(providerId);
-    if (!provider) {
-      return c.json({ error: "Provider not found" }, HTTP_STATUS.NOT_FOUND);
-    }
+      const provider = dbUtils.getProviderById(providerId);
+      if (!provider) {
+        return c.json({ error: "Provider not found" }, HTTP_STATUS.NOT_FOUND);
+      }
 
-    if (provider.name !== "ollama") {
-      return c.json({ error: "Provider is not an Ollama instance" }, HTTP_STATUS.BAD_REQUEST);
-    }
+      if (provider.name !== "ollama") {
+        return c.json({ error: "Provider is not an Ollama instance" }, HTTP_STATUS.BAD_REQUEST);
+      }
 
-    if (!provider.enabled) {
-      return c.json({ error: "Provider is disabled" }, HTTP_STATUS.BAD_REQUEST);
-    }
+      if (!provider.enabled) {
+        return c.json({ error: "Provider is disabled" }, HTTP_STATUS.BAD_REQUEST);
+      }
 
-    const baseUrl = provider.base_url;
-    if (!baseUrl) {
-      return c.json({ error: "Provider base URL not configured" }, HTTP_STATUS.BAD_REQUEST);
-    }
+      const baseUrl = provider.base_url;
+      if (!baseUrl) {
+        return c.json({ error: "Provider base URL not configured" }, HTTP_STATUS.BAD_REQUEST);
+      }
 
-    // Remove /v1 suffix if present (Ollama API doesn't use /v1 for pull endpoint)
-    const ollamaBaseUrl = baseUrl.replace(/\/v1\/?$/, "");
+      // Remove /v1 suffix if present (Ollama API doesn't use /v1 for pull endpoint)
+      const ollamaBaseUrl = baseUrl.replace(/\/v1\/?$/, "");
 
-    return streamSSE(c, async (stream) => {
-      try {
-        const pullUrl = `${ollamaBaseUrl}/api/pull`;
-        if (debug) console.log(`[Ollama Pull] Starting pull for model: ${modelName}`);
-        if (debug) console.log(`[Ollama Pull] URL: ${pullUrl}`);
+      return streamSSE(c, async (stream) => {
+        try {
+          const pullUrl = `${ollamaBaseUrl}/api/pull`;
+          if (debug) console.log(`[Ollama Pull] Starting pull for model: ${modelName}`);
+          if (debug) console.log(`[Ollama Pull] URL: ${pullUrl}`);
 
-        const response = await fetch(pullUrl, {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ name: modelName, stream: true }),
-        });
-
-        if (debug)
-          console.log(`[Ollama Pull] Response status: ${response.status} ${response.statusText}`);
-
-        if (!response.ok) {
-          const errorText = await response.text();
-          console.error(`[Ollama Pull] Error response: ${errorText}`);
-          await stream.writeSSE({
-            data: JSON.stringify({
-              status: "error",
-              error: `Ollama API error: ${response.statusText} - ${errorText}`,
-            }),
+          const response = await fetch(pullUrl, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ name: modelName, stream: true }),
           });
-          return;
-        }
 
-        const reader = response.body.getReader();
-        const decoder = new TextDecoder();
-        let buffer = "";
-        let chunkCount = 0;
+          if (debug)
+            console.log(`[Ollama Pull] Response status: ${response.status} ${response.statusText}`);
 
-        if (debug) console.log(`[Ollama Pull] Starting to read stream...`);
-
-        while (true) {
-          const { done, value } = await reader.read();
-          if (done) {
-            if (debug) console.log(`[Ollama Pull] Stream done after ${chunkCount} chunks`);
-            break;
+          if (!response.ok) {
+            const errorText = await response.text();
+            console.error(`[Ollama Pull] Error response: ${errorText}`);
+            await stream.writeSSE({
+              data: JSON.stringify({
+                status: "error",
+                error: `Ollama API error: ${response.statusText} - ${errorText}`,
+              }),
+            });
+            return;
           }
 
-          chunkCount++;
-          const chunk = decoder.decode(value, { stream: true });
-          buffer += chunk;
+          const reader = response.body.getReader();
+          const decoder = new TextDecoder();
+          let buffer = "";
+          let chunkCount = 0;
 
-          if (debug && chunkCount <= 3) {
-            console.log(`[Ollama Pull] Chunk ${chunkCount}: ${chunk.substring(0, 200)}`);
+          if (debug) console.log(`[Ollama Pull] Starting to read stream...`);
+
+          while (true) {
+            const { done, value } = await reader.read();
+            if (done) {
+              if (debug) console.log(`[Ollama Pull] Stream done after ${chunkCount} chunks`);
+              break;
+            }
+
+            chunkCount++;
+            const chunk = decoder.decode(value, { stream: true });
+            buffer += chunk;
+
+            if (debug && chunkCount <= 3) {
+              console.log(`[Ollama Pull] Chunk ${chunkCount}: ${chunk.substring(0, 200)}`);
+            }
+
+            const lines = buffer.split("\n");
+
+            // Keep the last (potentially incomplete) line in the buffer
+            buffer = lines.pop() || "";
+
+            for (const line of lines) {
+              if (!line.trim()) continue;
+              try {
+                const data = JSON.parse(line);
+
+                // Check if Ollama returned an error
+                if (data.error) {
+                  console.error(`[Ollama Pull] Ollama error: ${data.error}`);
+                  await stream.writeSSE({
+                    data: JSON.stringify({
+                      status: "error",
+                      error: data.error,
+                    }),
+                  });
+                  return; // Stop processing - we hit an error
+                }
+
+                await stream.writeSSE({ data: JSON.stringify(data) });
+
+                if (data.status === "success") {
+                  if (debug) console.log(`[Ollama Pull] Model ${modelName} pulled successfully!`);
+                }
+              } catch (parseError) {
+                console.error(
+                  "[Ollama Pull] Failed to parse line:",
+                  line.substring(0, 100),
+                  parseError.message
+                );
+              }
+            }
           }
 
-          const lines = buffer.split("\n");
-
-          // Keep the last (potentially incomplete) line in the buffer
-          buffer = lines.pop() || "";
-
-          for (const line of lines) {
-            if (!line.trim()) continue;
+          // Process any remaining buffer content
+          if (buffer.trim()) {
+            if (debug)
+              console.log(`[Ollama Pull] Processing final buffer: ${buffer.substring(0, 100)}`);
             try {
-              const data = JSON.parse(line);
+              const data = JSON.parse(buffer);
 
               // Check if Ollama returned an error
               if (data.error) {
-                console.error(`[Ollama Pull] Ollama error: ${data.error}`);
+                console.error(`[Ollama Pull] Ollama error in final buffer: ${data.error}`);
                 await stream.writeSSE({
                   data: JSON.stringify({
                     status: "error",
                     error: data.error,
                   }),
                 });
-                return; // Stop processing - we hit an error
+                return;
               }
 
               await stream.writeSSE({ data: JSON.stringify(data) });
-
-              if (data.status === "success") {
-                if (debug) console.log(`[Ollama Pull] Model ${modelName} pulled successfully!`);
-              }
             } catch (parseError) {
               console.error(
-                "[Ollama Pull] Failed to parse line:",
-                line.substring(0, 100),
+                "[Ollama Pull] Failed to parse final buffer:",
+                buffer.substring(0, 100),
                 parseError.message
               );
             }
           }
+
+          if (debug) console.log(`[Ollama Pull] Sending completed event`);
+          await stream.writeSSE({ data: JSON.stringify({ status: "completed" }) });
+        } catch (error) {
+          console.error("Ollama pull error:", error);
+          await stream.writeSSE({
+            data: JSON.stringify({
+              status: "error",
+              error: error.message || "Failed to pull model",
+            }),
+          });
         }
-
-        // Process any remaining buffer content
-        if (buffer.trim()) {
-          if (debug)
-            console.log(`[Ollama Pull] Processing final buffer: ${buffer.substring(0, 100)}`);
-          try {
-            const data = JSON.parse(buffer);
-
-            // Check if Ollama returned an error
-            if (data.error) {
-              console.error(`[Ollama Pull] Ollama error in final buffer: ${data.error}`);
-              await stream.writeSSE({
-                data: JSON.stringify({
-                  status: "error",
-                  error: data.error,
-                }),
-              });
-              return;
-            }
-
-            await stream.writeSSE({ data: JSON.stringify(data) });
-          } catch (parseError) {
-            console.error(
-              "[Ollama Pull] Failed to parse final buffer:",
-              buffer.substring(0, 100),
-              parseError.message
-            );
-          }
-        }
-
-        if (debug) console.log(`[Ollama Pull] Sending completed event`);
-        await stream.writeSSE({ data: JSON.stringify({ status: "completed" }) });
-      } catch (error) {
-        console.error("Ollama pull error:", error);
-        await stream.writeSSE({
-          data: JSON.stringify({
-            status: "error",
-            error: error.message || "Failed to pull model",
-          }),
-        });
+      });
+    } catch (error) {
+      if (error instanceof z.ZodError) {
+        return c.json({ error: "Invalid input", details: error.errors }, HTTP_STATUS.BAD_REQUEST);
       }
-    });
-  } catch (error) {
-    if (error instanceof z.ZodError) {
-      return c.json({ error: "Invalid input", details: error.errors }, HTTP_STATUS.BAD_REQUEST);
+      console.error("Pull model error:", error);
+      return c.json({ error: "Failed to pull model" }, HTTP_STATUS.INTERNAL_SERVER_ERROR);
     }
-    console.error("Pull model error:", error);
-    return c.json({ error: "Failed to pull model" }, HTTP_STATUS.INTERNAL_SERVER_ERROR);
   }
-});
+);
 
 // Mount routers
-modelsRouter.route("/admin/models", adminRouter);
+modelsRouter.route("/admin/models", adminModelsRouter);
 modelsRouter.route("/models", publicRouter);

--- a/server/src/routes/providers.js
+++ b/server/src/routes/providers.js
@@ -1,5 +1,7 @@
 import { Hono } from "hono";
 import { z } from "zod";
+import net from "node:net";
+import dns from "node:dns";
 import { dbUtils } from "../lib/db.js";
 import { encryptApiKey, decryptApiKey } from "../lib/encryption.js";
 import { ensureSession, requireRole } from "../middleware/auth.js";
@@ -42,19 +44,102 @@ function normalizeBaseUrl(providerName, baseUrl) {
   return baseUrl || null;
 }
 
+const BLOCKED_HOSTNAMES = new Set([
+  "localhost",
+  "ip6-localhost",
+  "ip6-loopback",
+  "169.254.169.254",
+  "metadata.google.internal",
+  "100.100.100.200",
+]);
+
+function isPrivateIPv4(ip) {
+  const parts = ip.split(".").map((p) => parseInt(p, 10));
+  if (parts.length !== 4 || parts.some((p) => Number.isNaN(p))) return false;
+  const [a, b] = parts;
+  if (a === 127) return true; // 127.0.0.0/8 loopback
+  if (a === 10) return true; // 10.0.0.0/8 private
+  if (a === 172 && b >= 16 && b <= 31) return true; // 172.16.0.0/12 private
+  if (a === 192 && b === 168) return true; // 192.168.0.0/16 private
+  if (a === 169 && b === 254) return true; // 169.254.0.0/16 link-local
+  if (a === 0) return true; // 0.0.0.0/8
+  return false;
+}
+
+function isPrivateIPv6(ip) {
+  const lower = ip.toLowerCase();
+  if (lower === "::1") return true; // loopback
+  if (lower === "::") return true; // unspecified
+  // ::ffff:a.b.c.d IPv4-mapped
+  if (lower.startsWith("::ffff:")) {
+    const tail = lower.slice(7);
+    if (tail.includes(".")) return isPrivateIPv4(tail);
+    // hex form ::ffff:7f00:1 etc — convert last two hextets to dotted
+    const parts = tail.split(":");
+    if (parts.length === 2) {
+      const hi = parseInt(parts[0], 16);
+      const lo = parseInt(parts[1], 16);
+      if (!Number.isNaN(hi) && !Number.isNaN(lo)) {
+        const dotted = `${(hi >> 8) & 0xff}.${hi & 0xff}.${(lo >> 8) & 0xff}.${lo & 0xff}`;
+        return isPrivateIPv4(dotted);
+      }
+    }
+  }
+  // fe80::/10 link-local
+  if (/^fe[89ab][0-9a-f]?:/.test(lower)) return true;
+  // fc00::/7 unique-local
+  if (/^f[cd][0-9a-f]{2}:/.test(lower)) return true;
+  return false;
+}
+
+function isPrivateAddress(ip) {
+  const family = net.isIP(ip);
+  if (family === 4) return isPrivateIPv4(ip);
+  if (family === 6) return isPrivateIPv6(ip);
+  return false;
+}
+
 /**
  * Validate provider base URL to prevent SSRF
+ *
+ * TODO: DNS rebinding is out of scope; validation + fetch is a TOCTOU race.
  */
-function validateProviderUrl(url) {
+async function validateProviderUrl(url) {
+  let parsed;
   try {
-    const parsed = new URL(url);
-    const blockedHosts = ["169.254.169.254", "metadata.google.internal", "100.100.100.200"];
-    if (blockedHosts.includes(parsed.hostname)) return false;
-    if (!["http:", "https:"].includes(parsed.protocol)) return false;
-    return true;
+    parsed = new URL(url);
   } catch {
     return false;
   }
+  if (!["http:", "https:"].includes(parsed.protocol)) return false;
+
+  // Bun's URL keeps brackets on IPv6 hostnames; strip them so net.isIP / DNS see the bare address
+  let hostname = parsed.hostname;
+  if (!hostname) return false;
+  if (hostname.startsWith("[") && hostname.endsWith("]")) {
+    hostname = hostname.slice(1, -1);
+  }
+
+  const lowerHost = hostname.toLowerCase();
+  if (BLOCKED_HOSTNAMES.has(lowerHost)) return false;
+
+  // If hostname is itself an IP literal, classify directly
+  if (net.isIP(hostname)) {
+    return !isPrivateAddress(hostname);
+  }
+
+  // Otherwise resolve and check every returned address
+  let addresses;
+  try {
+    addresses = await dns.promises.lookup(hostname, { all: true });
+  } catch {
+    return false;
+  }
+  if (!addresses || addresses.length === 0) return false;
+  for (const { address } of addresses) {
+    if (isPrivateAddress(address)) return false;
+  }
+  return true;
 }
 
 // Validation schemas
@@ -166,7 +251,7 @@ providersRouter.post("/", async (c) => {
     const normalizedBaseUrl = normalizeBaseUrl(name, baseUrl);
 
     // SSRF validation for local provider base URLs
-    if (normalizedBaseUrl && !validateProviderUrl(normalizedBaseUrl)) {
+    if (normalizedBaseUrl && !(await validateProviderUrl(normalizedBaseUrl))) {
       return c.json({ error: "Invalid base URL" }, HTTP_STATUS.BAD_REQUEST);
     }
 
@@ -259,7 +344,7 @@ providersRouter.put("/:id", async (c) => {
     }
 
     // SSRF validation if base URL is being updated
-    if (updates.baseUrl && !validateProviderUrl(updates.baseUrl)) {
+    if (updates.baseUrl && !(await validateProviderUrl(updates.baseUrl))) {
       return c.json({ error: "Invalid base URL" }, HTTP_STATUS.BAD_REQUEST);
     }
 
@@ -446,7 +531,7 @@ async function fetchModelsForProvider(providerName, baseUrl, providerType, displ
  * Fetch models from Ollama
  */
 async function fetchOllamaModels(baseUrl) {
-  if (!validateProviderUrl(baseUrl)) {
+  if (!(await validateProviderUrl(baseUrl))) {
     throw new Error("Invalid Ollama base URL");
   }
   try {
@@ -494,7 +579,7 @@ async function fetchOllamaModels(baseUrl) {
  * Used by lmstudio, llama-cpp, and llamafile providers
  */
 async function fetchOpenAICompatibleModels(baseUrl, displayProvider = "OpenAI-compatible server") {
-  if (!validateProviderUrl(baseUrl)) {
+  if (!(await validateProviderUrl(baseUrl))) {
     throw new Error(`Invalid ${displayProvider} base URL`);
   }
   try {

--- a/server/src/test/chats.completion.test.js
+++ b/server/src/test/chats.completion.test.js
@@ -1,0 +1,147 @@
+import { describe, test, expect, beforeAll, mock } from "bun:test";
+
+// Capture streamText calls before any module that imports `ai` is loaded.
+const streamTextCalls = [];
+const aiActual = await import("ai");
+mock.module("ai", () => ({
+  ...aiActual,
+  streamText: (opts) => {
+    streamTextCalls.push(opts);
+    return {
+      text: Promise.resolve(""),
+      toUIMessageStreamResponse: () =>
+        new Response("data: [DONE]\n\n", {
+          status: 200,
+          headers: { "Content-Type": "text/event-stream" },
+        }),
+    };
+  },
+}));
+
+// Stub provider factory so getModel() doesn't try to talk to a real LLM.
+mock.module("../lib/providerFactory.js", () => ({
+  createProviderInstance: () => ({}),
+  getModelInstance: () => ({ modelId: "stub-model" }),
+}));
+
+const { createTestApp, resetDatabase, seedAdminUser, makeRequest } = await import("./helpers.js");
+const { dbUtils } = await import("../lib/db.js");
+const { encryptApiKey } = await import("../lib/encryption.js");
+const fsPromises = await import("fs/promises");
+const { writeFile, mkdir } = fsPromises;
+const pathMod = await import("path");
+const path = pathMod.default || pathMod;
+const { FILE_CONFIG } = await import("../lib/fileUtils.js");
+
+describe("chat completion - file history preservation", () => {
+  let app, adminCookie, adminUserId, chatId, fileId, msg1Id, msg2Id;
+
+  beforeAll(async () => {
+    resetDatabase();
+    app = createTestApp();
+    const admin = await seedAdminUser(app);
+    adminCookie = admin.cookie;
+    adminUserId = admin.user.id;
+
+    // Seed provider + enabled model so getModel(modelId) succeeds.
+    const { encryptedKey, iv, authTag } = encryptApiKey("sk-test-key");
+    const providerId = dbUtils.createProvider(
+      "test-provider",
+      "Test Provider",
+      "official",
+      null,
+      encryptedKey,
+      iv,
+      authTag
+    );
+    dbUtils.createModel(providerId, "stub-model", "Stub Model", true, "text");
+
+    // Create a chat.
+    const chatRes = await makeRequest(app, "POST", "/api/chats", {
+      body: { title: "File history chat" },
+      cookie: adminCookie,
+    });
+    chatId = (await chatRes.json()).id;
+
+    // Materialize a tiny PNG on disk and register it as a file owned by admin.
+    await mkdir(FILE_CONFIG.UPLOAD_DIR, { recursive: true });
+    fileId = `test-file-${crypto.randomUUID()}`;
+    const storedFilename = `${fileId}.png`;
+    const filePath = path.join(FILE_CONFIG.UPLOAD_DIR, storedFilename);
+    // 1x1 transparent PNG bytes
+    const pngBytes = Buffer.from(
+      "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNgAAIAAAUAAen63NgAAAAASUVORK5CYII=",
+      "base64"
+    );
+    await writeFile(filePath, pngBytes);
+    dbUtils.createFile(
+      fileId,
+      adminUserId,
+      "tiny.png",
+      storedFilename,
+      filePath,
+      "image/png",
+      pngBytes.length,
+      null,
+      null
+    );
+
+    // Persist message 1 (with file attached) and message 2 (follow-up, no file).
+    const m1Res = await makeRequest(app, "POST", `/api/chats/${chatId}/messages`, {
+      body: { role: "user", content: "analyze this", fileIds: [fileId] },
+      cookie: adminCookie,
+    });
+    msg1Id = (await m1Res.json()).id;
+
+    const m2Res = await makeRequest(app, "POST", `/api/chats/${chatId}/messages`, {
+      body: { role: "user", content: "follow up question", fileIds: [] },
+      cookie: adminCookie,
+    });
+    msg2Id = (await m2Res.json()).id;
+  });
+
+  test("historic user message with fileIds is sent to model as multimodal content", async () => {
+    streamTextCalls.length = 0;
+
+    const res = await makeRequest(app, "POST", `/api/chats/${chatId}/completion`, {
+      body: {
+        model: "stub-model",
+        systemPromptId: "default",
+        messages: [
+          {
+            id: msg1Id,
+            role: "user",
+            content: "analyze this",
+            fileIds: [fileId],
+          },
+          {
+            id: msg2Id,
+            role: "user",
+            content: "follow up question",
+            fileIds: [],
+          },
+        ],
+      },
+      cookie: adminCookie,
+    });
+
+    expect(res.status).toBe(200);
+    expect(streamTextCalls.length).toBe(1);
+
+    const sent = streamTextCalls[0].messages;
+    // Find the historic message 1 ("analyze this") in the messages passed to streamText.
+    const historicUserMsg = sent.find(
+      (m) =>
+        m.role === "user" &&
+        Array.isArray(m.content) &&
+        m.content.some((p) => p.type === "text" && p.text === "analyze this")
+    );
+    expect(historicUserMsg).toBeDefined();
+
+    // It must carry a multimodal part for the file (image or file), not just text.
+    const fileParts = historicUserMsg.content.filter(
+      (p) => p.type === "image" || p.type === "file"
+    );
+    expect(fileParts.length).toBeGreaterThan(0);
+  });
+});

--- a/server/src/test/chats.test.js
+++ b/server/src/test/chats.test.js
@@ -6,6 +6,11 @@ import {
   seedMemberUser,
   makeRequest,
 } from "./helpers.js";
+import { dbUtils } from "../lib/db.js";
+import { createMultimodalContent } from "../routes/chats.js";
+import { unlink } from "fs/promises";
+import path from "path";
+import { FILE_CONFIG } from "../lib/fileUtils.js";
 
 describe("chat routes", () => {
   let app, adminCookie, memberCookie;
@@ -374,6 +379,142 @@ describe("chat routes", () => {
       expect(data.limit).toBe(2);
       expect(data.offset).toBe(0);
       expect(data.chats.length).toBeLessThanOrEqual(2);
+    });
+  });
+
+  describe("file error surfacing", () => {
+    test("createMultimodalContent throws when physical file is missing instead of swallowing", async () => {
+      const adminUser = dbUtils.getUserByUsername("admin");
+      const fileId = `missing-file-${crypto.randomUUID()}`;
+      const storedFilename = `${fileId}.bin`;
+      const filePath = path.join(FILE_CONFIG.UPLOAD_DIR, storedFilename);
+
+      dbUtils.createFile(
+        fileId,
+        adminUser.id,
+        "ghost.png",
+        storedFilename,
+        filePath,
+        "image/png",
+        100,
+        null,
+        null
+      );
+
+      // Ensure no physical file exists
+      try {
+        await unlink(filePath);
+      } catch {
+        /* not present, ok */
+      }
+
+      let threw = false;
+      try {
+        await createMultimodalContent({ content: "hello" }, [fileId], adminUser.id);
+      } catch {
+        threw = true;
+      }
+      expect(threw).toBe(true);
+
+      dbUtils.deleteFile(fileId);
+    });
+  });
+
+  describe("folderId contract", () => {
+    test("GET /api/chats returns chat objects with camelCase folderId key", async () => {
+      const res = await makeRequest(app, "GET", "/api/chats", {
+        cookie: adminCookie,
+      });
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.chats.length).toBeGreaterThanOrEqual(1);
+      for (const chat of data.chats) {
+        expect(chat).toHaveProperty("folderId");
+        expect(chat).not.toHaveProperty("folder_id");
+      }
+    });
+
+    test("POST /api/chats with folder_id returns folderId (camelCase) in response", async () => {
+      const folderRes = await makeRequest(app, "POST", "/api/folders", {
+        body: { name: "Contract Folder" },
+        cookie: adminCookie,
+      });
+      expect(folderRes.status).toBe(201);
+      const folderData = await folderRes.json();
+      const folderId = folderData.folder?.id || folderData.id;
+
+      const res = await makeRequest(app, "POST", "/api/chats", {
+        body: { folder_id: folderId },
+        cookie: adminCookie,
+      });
+      expect(res.status).toBe(201);
+      const data = await res.json();
+      expect(data).toHaveProperty("folderId", folderId);
+      expect(data).not.toHaveProperty("folder_id");
+    });
+  });
+
+  describe("title fallback", () => {
+    test("AI title generation failure falls back to truncated content", async () => {
+      const createRes = await makeRequest(app, "POST", "/api/chats", {
+        body: {},
+        cookie: adminCookie,
+      });
+      expect(createRes.status).toBe(201);
+      const { id: chatId } = await createRes.json();
+
+      const userContent = "Hello world, please help me plan a trip to Japan next spring";
+
+      // Use a non-existent model ID so generateChatTitle's underlying call fails.
+      const msgRes = await makeRequest(app, "POST", `/api/chats/${chatId}/messages`, {
+        body: {
+          role: "user",
+          content: userContent,
+          model: "non-existent-model-for-fallback-test",
+        },
+        cookie: adminCookie,
+      });
+      expect(msgRes.status).toBe(201);
+
+      const getRes = await makeRequest(app, "GET", `/api/chats/${chatId}`, {
+        cookie: adminCookie,
+      });
+      expect(getRes.status).toBe(200);
+      const chat = await getRes.json();
+      expect(chat.title).not.toBeNull();
+      expect(typeof chat.title).toBe("string");
+      // The fallback should match what truncateToTitle would return
+      // (For short content, it's the content verbatim; for long, it's truncated.)
+      const expectedPrefix = userContent.slice(0, 40);
+      expect(chat.title.startsWith(expectedPrefix.slice(0, 20))).toBe(true);
+    });
+
+    test("first user message with no model still gets a title via direct truncation", async () => {
+      const createRes = await makeRequest(app, "POST", "/api/chats", {
+        body: {},
+        cookie: adminCookie,
+      });
+      expect(createRes.status).toBe(201);
+      const { id: chatId } = await createRes.json();
+
+      const userContent = "Short prompt without a model";
+
+      const msgRes = await makeRequest(app, "POST", `/api/chats/${chatId}/messages`, {
+        body: {
+          role: "user",
+          content: userContent,
+          // No model field — must skip AI path entirely.
+        },
+        cookie: adminCookie,
+      });
+      expect(msgRes.status).toBe(201);
+
+      const getRes = await makeRequest(app, "GET", `/api/chats/${chatId}`, {
+        cookie: adminCookie,
+      });
+      expect(getRes.status).toBe(200);
+      const chat = await getRes.json();
+      expect(chat.title).toBe(userContent);
     });
   });
 });

--- a/server/src/test/memory.test.js
+++ b/server/src/test/memory.test.js
@@ -1,5 +1,6 @@
-import { describe, test, expect } from "bun:test";
+import { describe, test, expect, mock } from "bun:test";
 import { createMemoryMiddleware, isMemoryEnabledForRequest } from "../lib/memory.js";
+import { MEMORY_EXTRACTION_MAX_FACTS_PER_TURN } from "@faster-chat/shared";
 
 describe("memory helpers", () => {
   test("isMemoryEnabledForRequest requires all memory gates to pass", () => {
@@ -60,6 +61,37 @@ describe("memory helpers", () => {
 
     expect(result.system).toContain("Base system prompt");
     expect(result.system).toContain("uses Arch Linux");
+  });
+
+  test("extractMemories caps persisted facts to MEMORY_EXTRACTION_MAX_FACTS_PER_TURN", async () => {
+    const fiftyFacts = Array.from({ length: 50 }, (_, i) => `fact ${i}`);
+    await mock.module("ai", () => ({
+      wrapLanguageModel: (opts) => opts.model,
+      generateText: async () => ({ text: JSON.stringify(fiftyFacts) }),
+    }));
+
+    // Re-import after mock so memory.js binds to mocked generateText
+    const { extractMemories } = await import(`../lib/memory.js?cap=${Date.now()}`);
+
+    let receivedFacts = null;
+    const dbUtils = {
+      upsertMemories: (_userId, facts) => {
+        receivedFacts = facts;
+      },
+    };
+
+    await extractMemories({
+      model: {},
+      userMessage: "hi",
+      assistantMessage: "hello",
+      userId: 1,
+      chatId: "chat-1",
+      dbUtils,
+    });
+
+    expect(receivedFacts).not.toBeNull();
+    expect(receivedFacts.length).toBe(MEMORY_EXTRACTION_MAX_FACTS_PER_TURN);
+    expect(receivedFacts.length).toBe(10);
   });
 
   test("memory middleware skips injection when the request disables memory", async () => {

--- a/server/src/test/models.test.js
+++ b/server/src/test/models.test.js
@@ -174,6 +174,22 @@ describe("model routes", () => {
     });
   });
 
+  describe("updateModel default atomicity", () => {
+    test("only the most recently set default model has is_default = 1", () => {
+      const modelA = dbUtils.createModel(providerId, "atomic-a", "Atomic A", true, "text");
+      const modelB = dbUtils.createModel(providerId, "atomic-b", "Atomic B", true, "text");
+
+      dbUtils.updateModel(modelA, { isDefault: true });
+      dbUtils.updateModel(modelB, { isDefault: true });
+
+      const a = dbUtils.getModelById(modelA);
+      const b = dbUtils.getModelById(modelB);
+
+      expect(a.is_default).toBe(0);
+      expect(b.is_default).toBe(1);
+    });
+  });
+
   describe("DELETE /api/admin/models/:id", () => {
     let deleteModelId;
 

--- a/server/src/test/providers.test.js
+++ b/server/src/test/providers.test.js
@@ -1,4 +1,5 @@
 import { describe, test, expect, beforeAll, afterAll } from "bun:test";
+import dns from "node:dns";
 import {
   createTestApp,
   resetDatabase,
@@ -7,6 +8,14 @@ import {
   makeRequest,
 } from "./helpers.js";
 import { dbUtils } from "../lib/db.js";
+
+// Stub DNS so tests using fictitious hostnames don't depend on real network resolution.
+// Returns a public-looking (TEST-NET-3) IP for any hostname.
+dns.promises.lookup = async (_hostname, opts) => {
+  const all = opts && opts.all;
+  const result = [{ address: "203.0.113.10", family: 4 }];
+  return all ? result : result[0];
+};
 
 describe("provider routes", () => {
   let app, adminCookie, memberCookie;
@@ -113,6 +122,80 @@ describe("provider routes", () => {
         cookie: adminCookie,
       });
       expect(res.status).toBe(400);
+    });
+
+    // Comprehensive SSRF rejection cases — POST creation
+    const REJECT_CASES = [
+      ["loopback IPv4", "http://127.0.0.1:11434"],
+      ["localhost hostname", "http://localhost:8080"],
+      ["10.0.0.0/8 private", "http://10.0.0.5/"],
+      ["192.168.0.0/16 private", "http://192.168.1.1/"],
+      ["172.16.0.0/12 private", "http://172.16.0.1/"],
+      ["AWS metadata service", "http://169.254.169.254/"],
+      ["unspecified 0.0.0.0", "http://0.0.0.0/"],
+      ["IPv6 loopback ::1", "http://[::1]/"],
+      ["IPv4-mapped IPv6 loopback", "http://[::ffff:127.0.0.1]/"],
+      ["non-http(s) ftp scheme", "ftp://example.com/"],
+    ];
+
+    for (const [label, url] of REJECT_CASES) {
+      test(`POST rejects ${label}: ${url}`, async () => {
+        const res = await makeRequest(app, "POST", "/api/admin/providers", {
+          body: {
+            name: `ssrf-post-${label.replace(/\W+/g, "-")}`,
+            displayName: "ssrf",
+            providerType: "openai-compatible",
+            baseUrl: url,
+            apiKey: "sk-test-key",
+          },
+          cookie: adminCookie,
+        });
+        expect([400, 422]).toContain(res.status);
+      });
+    }
+
+    test("POST accepts valid public https URL", async () => {
+      const res = await makeRequest(app, "POST", "/api/admin/providers", {
+        body: {
+          name: "ssrf-accept-public",
+          displayName: "Public OpenAI",
+          providerType: "openai-compatible",
+          baseUrl: "https://api.openai.com/v1",
+          apiKey: "sk-public-key",
+        },
+        cookie: adminCookie,
+      });
+      // Provider creation succeeds with 201 even if model fetch fails
+      expect(res.status).toBe(201);
+    });
+
+    describe("PUT rejection mirror", () => {
+      let putTargetId;
+
+      beforeAll(async () => {
+        const createRes = await makeRequest(app, "POST", "/api/admin/providers", {
+          body: {
+            name: "ssrf-put-target",
+            displayName: "PUT target",
+            providerType: "openai-compatible",
+            baseUrl: "https://api.example-public.com/v1",
+            apiKey: "sk-put-key",
+          },
+          cookie: adminCookie,
+        });
+        const data = await createRes.json();
+        putTargetId = data.provider.id;
+      });
+
+      for (const [label, url] of REJECT_CASES) {
+        test(`PUT rejects ${label}: ${url}`, async () => {
+          const res = await makeRequest(app, "PUT", `/api/admin/providers/${putTargetId}`, {
+            body: { baseUrl: url },
+            cookie: adminCookie,
+          });
+          expect([400, 422]).toContain(res.status);
+        });
+      }
     });
   });
 
@@ -388,7 +471,7 @@ describe("provider routes", () => {
             name: "llama-cpp",
             displayName: "llama.cpp",
             providerType: "openai-compatible",
-            baseUrl: "http://localhost:8080",
+            baseUrl: "http://llama-cpp.test.local:8080",
             apiKey: "sk-test",
           },
           cookie: adminCookie,
@@ -432,7 +515,7 @@ describe("provider routes", () => {
             name: "llamafile",
             displayName: "Llamafile",
             providerType: "openai-compatible",
-            baseUrl: "http://localhost:8081",
+            baseUrl: "http://llamafile.test.local:8081",
             apiKey: "sk-test",
           },
           cookie: adminCookie,
@@ -461,7 +544,7 @@ describe("provider routes", () => {
       beforeAll(async () => {
         llamaCppUrlnormId = await createTestProvider({
           name: "llama-cpp-urlnorm",
-          baseUrl: "http://localhost:8082",
+          baseUrl: "http://urlnorm.test.local:8082",
         });
 
         globalThis.fetch = async (input, init) => {
@@ -487,7 +570,7 @@ describe("provider routes", () => {
           "PUT",
           `/api/admin/providers/${llamaCppUrlnormId}`,
           {
-            body: { baseUrl: "http://localhost:8082/v1" },
+            body: { baseUrl: "http://urlnorm.test.local:8082/v1" },
             cookie: adminCookie,
           }
         );
@@ -500,7 +583,7 @@ describe("provider routes", () => {
           { cookie: adminCookie }
         );
         expect(refreshRes.status).toBe(200);
-        expect(capturedUrl).toBe("http://localhost:8082/v1/models");
+        expect(capturedUrl).toBe("http://urlnorm.test.local:8082/v1/models");
         expect(capturedUrl).not.toContain("/v1/v1/models");
       });
     });
@@ -518,7 +601,7 @@ describe("provider routes", () => {
 
         embedProviderId = await createTestProvider({
           name: "llama-cpp-embed",
-          baseUrl: "http://localhost:8083",
+          baseUrl: "http://embed.test.local:8083",
         });
       });
 
@@ -555,7 +638,7 @@ describe("provider routes", () => {
 
         errorProviderId = await createTestProvider({
           name: "llama-cpp-error",
-          baseUrl: "http://localhost:8084",
+          baseUrl: "http://error-host.test.local:8084",
         });
 
         globalThis.fetch = async () => {
@@ -602,7 +685,7 @@ describe("provider routes", () => {
 
         invalidProviderId = await createTestProvider({
           name: "llama-cpp-invalid",
-          baseUrl: "http://localhost:8085",
+          baseUrl: "http://invalid-host.test.local:8085",
         });
       });
 
@@ -665,7 +748,7 @@ describe("provider routes", () => {
           name: "ollama",
           displayName: "ollama",
           providerType: "openai-compatible",
-          baseUrl: "http://localhost:11434",
+          baseUrl: "http://ollama.test.local:11434",
           apiKey: "sk-test",
         },
         cookie: adminCookie,


### PR DESCRIPTION
## Summary

Closes all 13 findings from the data-flow review: 2 critical, 5 high, 4 medium, 2 low. Each fix traces to its finding; no adjacent code was changed.

### Security (CRIT-2, CRIT-1)

**SSRF validator rewrite** (`providers.js`): The old validator blocked three hardcoded hostnames. The new `validateProviderUrl` is async, resolves non-IP hostnames via DNS, and rejects all RFC-1918 (10.x, 172.16–31.x, 192.168.x), loopback (127.0.0.0/8), link-local (169.254.0.0/16), unspecified (0.0.0.0), IPv6 loopback (::1), link-local (fe80::/10), unique-local (fc00::/7), and IPv4-mapped equivalents. Applied at all four call sites. A TODO comment marks DNS-rebinding TOCTOU as out of scope.

**Title fallback** (`chats.js`): A failing `generateChatTitle` or `updateChatTitle` call left the chat with a null title. The fix computes `truncateToTitle` first as a guaranteed baseline, attempts the AI upgrade in an isolated try/catch (failure keeps the baseline), and catches `updateChatTitle` separately — logging failure rather than returning 500.

### Backend contract & data integrity (HIGH-3, HIGH-4, LOW-2, MED-2, MED-4, LOW-1)

**`folderId` consistency**: `GET /api/chats` omitted the folder field entirely; `POST /api/chats` returned `folder_id` (snake_case). Both now return `folderId`, eliminating the cache shape mismatch between optimistic entries and server data.

**File error surfacing**: Removed the swallowing try/catch in `createMultimodalContent`. A missing file now throws and returns 500. Before, it was silently dropped and the model received an empty context.

**Memory cap**: `extractMemories` slices `validFacts` to `MEMORY_EXTRACTION_MAX_FACTS_PER_TURN` (10) before upserting. Constant exported from shared package. Without the cap, a single verbose extraction turn could write unbounded rows to `user_memories`.

**Router rename**: `adminRouter` → `adminModelsRouter` in `routes/models.js`, removing the visual collision with the imported `adminRouter` from `routes/admin.js`.

**`updateModel` atomicity**: The two-statement default-flag sequence (clear all, set new) is now wrapped in `db.transaction()`. A crash between the two writes no longer leaves the database with no default model.

### Frontend cache shape (HIGH-1, HIGH-2, HIGH-5, MED-1)

**Folder cache shape** (`useFolders.js`): Removed `select: (data) => data.folders || []` from the list query; fixed hook return to `data?.folders ?? []`. Every `setQueryData`/`getQueryData` call already wrote `{folders: [...]}` — the select was the only diverging path, causing the folder sidebar to flash empty on rename.

**Canonical message shape** (`messageShape.js`): New `toCanonicalMessage` helper produces `{id, role, content, parts, fileIds, model, createdAt}`. Used in `useMessagesQuery.select`, `onMutate`, and `onSuccess`. Optimistic messages previously lacked `parts`, breaking regeneration and rendering for newly saved messages.

**Sort parity** (`chatSort.js`): New `sortChatsLikeServer` mirrors `ORDER BY pinned_at ASC NULLS LAST, updated_at DESC`. Replaces the plain `updatedAt` sort in optimistic updates — pinned chats no longer drop below unpinned ones when a message is sent.

**Folder invalidation on delete**: Added `onSettled` to `useDeleteChatMutation` calling `invalidateQueries({queryKey: ["folders"]})`. Deleted chats now vanish from folder views without requiring navigation.

### File history (MED-3)

`useChatStream.js` now includes `fileIds` on every message in the transport payload. `CompletionRequestSchema.messages[]` accepts optional `fileIds` per item; `convertToModelMessages` builds multimodal parts for historic user messages that carry file IDs. The top-level `fileIds` field is preserved as a legacy fallback for the last user message when it carries none of its own.

## Test plan

- [ ] `bun test` — 289 pass / 0 fail (baseline 260; +29 tests)
- [ ] Providers: 49/49 — SSRF rejection for all private ranges, public URL accepted
- [ ] Chats: 34/34 — `folderId` in list/create, title fallback on model error, file error surfacing
- [ ] Memory: 4/4 — extraction capped at 10 facts
- [ ] Models: 14/14 — `updateModel` default atomicity
- [ ] Completion: 1/1 — historic `fileIds` preserved in multimodal context
- [ ] Manual smoke: folder rename (no flicker), delete chat in folder (disappears immediately), pinned chat stays top after send, multi-turn file context works