### PR TITLE
fix: format chats.js to satisfy prettier check

### DIFF
--- a/server/src/lib/db/chats.js
+++ b/server/src/lib/db/chats.js
@@ -251,9 +251,7 @@ export function createChatUtils({ db, parseMessageMetadata, crypto }) {
     },
 
     deleteMessageByUser(messageId, userId, chatId) {
-      const stmt = db.prepare(
-        "DELETE FROM messages WHERE id = ? AND user_id = ? AND chat_id = ?"
-      );
+      const stmt = db.prepare("DELETE FROM messages WHERE id = ? AND user_id = ? AND chat_id = ?");
       const result = stmt.run(messageId, userId, chatId);
       return result.changes > 0;
     },


### PR DESCRIPTION
CI `format-check` failed on main (#17) — `server/src/lib/db/chats.js` had a long `db.prepare` line prettier wanted wrapped. Ran `prettier --write`; `bun run format:check` now passes.