### PR TITLE
fix: file delete ordering, provider sort comparator, upload orphan cleanup

### DIFF
--- a/server/src/lib/db/files.js
+++ b/server/src/lib/db/files.js
@@ -76,12 +76,6 @@ export function createFileUtils({ db, parseFileMeta }) {
       return result.changes > 0;
     },
 
-    deleteFileByUser(fileId, userId) {
-      const stmt = db.prepare("DELETE FROM files WHERE id = ? AND user_id = ?");
-      const result = stmt.run(fileId, userId);
-      return result.changes > 0;
-    },
-
     deleteFilesByUserId(userId) {
       const stmt = db.prepare("DELETE FROM files WHERE user_id = ?");
       const result = stmt.run(userId);

--- a/server/src/routes/files.js
+++ b/server/src/routes/files.js
@@ -1,5 +1,5 @@
 import { Hono } from "hono";
-import { writeFile } from "fs/promises";
+import { writeFile, unlink } from "fs/promises";
 import path from "path";
 import { fileURLToPath } from "url";
 import { dbUtils } from "../lib/db.js";
@@ -74,29 +74,28 @@ filesRouter.post("/", createRateLimiter(ENDPOINT_RATE_LIMITS.FILE_UPLOAD), async
 
   // Save file metadata to database
   const relativePath = path.join("server/data/uploads", storedFilename);
-  const fileRecord = dbUtils.createFile(
-    fileId,
-    user.id,
-    file.name,
-    storedFilename,
-    relativePath,
-    file.type,
-    file.size,
-    fileHash,
-    {
-      originalName: file.name,
-      originalMimeType: classification?.originalMimeType ?? file.type,
-      normalizedMimeType: classification?.effectiveMimeType ?? file.type,
-      attachmentCategory: classification?.category ?? null,
-      downloadPolicy: classification?.downloadPolicy ?? null,
-      uploadedAt: Date.now(),
-    }
-  );
-
-  if (!fileRecord) {
-    // Cleanup file if database insert failed
+  try {
+    dbUtils.createFile(
+      fileId,
+      user.id,
+      file.name,
+      storedFilename,
+      relativePath,
+      file.type,
+      file.size,
+      fileHash,
+      {
+        originalName: file.name,
+        originalMimeType: classification?.originalMimeType ?? file.type,
+        normalizedMimeType: classification?.effectiveMimeType ?? file.type,
+        attachmentCategory: classification?.category ?? null,
+        downloadPolicy: classification?.downloadPolicy ?? null,
+        uploadedAt: Date.now(),
+      }
+    );
+  } catch (err) {
     await deleteFileFromDisk(filePath);
-    return c.json({ error: "Failed to save file metadata" }, HTTP_STATUS.INTERNAL_SERVER_ERROR);
+    throw err;
   }
 
   return c.json({
@@ -192,18 +191,20 @@ filesRouter.delete("/:id", async (c) => {
     return c.json({ error: access.reason }, statusCode);
   }
 
-  // Delete from disk - use the path field which includes subdirectories
-  const filePath = path.join(PROJECT_ROOT, file.path);
-  await deleteFileFromDisk(filePath);
-
-  // Delete from database (scoped to owner as defense-in-depth)
-  const deleted = dbUtils.deleteFileByUser(fileId, user.id);
+  const deleted = dbUtils.deleteFile(fileId);
 
   if (!deleted) {
-    return c.json(
-      { error: "Failed to delete file from database" },
-      HTTP_STATUS.INTERNAL_SERVER_ERROR
-    );
+    return c.json({ error: "File not found" }, HTTP_STATUS.NOT_FOUND);
+  }
+
+  // Delete from disk - use the path field which includes subdirectories
+  const filePath = path.join(PROJECT_ROOT, file.path);
+  try {
+    await unlink(filePath);
+  } catch (error) {
+    if (error.code !== "ENOENT") {
+      console.error("Failed to delete file from disk:", error);
+    }
   }
 
   return c.json({ message: "File deleted successfully" });

--- a/server/src/routes/providers.js
+++ b/server/src/routes/providers.js
@@ -63,8 +63,8 @@ providersRouter.get("/available", async (c) => {
     (p) => !Object.keys(PROVIDERS).includes(p.id)
   );
   const allProviders = [...nativeProviders, ...filteredCommunity].sort((a, b) => {
-    const order = { "openai-compatible": 0, official: 1, community: 2 };
-    return order[a.type] - order[b.type];
+    const order = { local: 0, "openai-compatible": 0, official: 1, community: 2 };
+    return (order[a.type ?? a.category] ?? 3) - (order[b.type ?? b.category] ?? 3);
   });
   return c.json({ providers: allProviders });
 });
@@ -127,7 +127,9 @@ providersRouter.post("/", async (c) => {
       );
       if (model.metadata) dbUtils.setModelMetadata(modelId, model.metadata);
     }
-  } catch {}
+  } catch (error) {
+    console.error("Failed to fetch provider models:", error.message);
+  }
 
   return c.json(
     { provider: { id: providerId, name, display_name: displayName, model_count: models.length } },

--- a/server/src/test/files.test.js
+++ b/server/src/test/files.test.js
@@ -1,12 +1,12 @@
 import { describe, it, expect, beforeAll, afterAll } from "bun:test";
 import path from "path";
-import { mkdir, writeFile, rm } from "fs/promises";
-import { createTestApp, seedAdminUser, makeRequest } from "./helpers.js";
+import { mkdir, writeFile, rm, readdir } from "fs/promises";
+import { createTestApp, seedAdminUser, seedMemberUser, makeRequest, db } from "./helpers.js";
 import { encryptApiKey } from "../lib/encryption.js";
 import { FILE_CONFIG } from "../lib/fileUtils.js";
 
 describe("file routes", () => {
-  let app, adminCookie, adminUserId;
+  let app, adminCookie, adminUserId, memberCookie, memberUserId;
 
   beforeAll(async () => {
     const { resetDatabase } = await import("./helpers.js");
@@ -15,6 +15,9 @@ describe("file routes", () => {
     const admin = await seedAdminUser(app);
     adminCookie = admin.cookie;
     adminUserId = admin.user.id;
+    const member = await seedMemberUser(app, adminCookie);
+    memberCookie = member.cookie;
+    memberUserId = member.user.id;
 
     // Ensure upload directory exists
     await mkdir(FILE_CONFIG.UPLOAD_DIR, { recursive: true });
@@ -242,6 +245,51 @@ describe("file routes", () => {
     });
   });
 
+  describe("DELETE /api/files/:id", () => {
+    async function createFileFixture(fileId, ownerId) {
+      const { dbUtils } = await import("../lib/db.js");
+      const storedFilename = `${fileId}.txt`;
+      const filePath = path.join(FILE_CONFIG.UPLOAD_DIR, storedFilename);
+      await writeFile(filePath, Buffer.from("delete test"));
+      dbUtils.createFile(
+        fileId,
+        ownerId,
+        `${fileId}.txt`,
+        storedFilename,
+        `server/data/uploads/${storedFilename}`,
+        "text/plain",
+        11
+      );
+      return { dbUtils, filePath };
+    }
+
+    it("allows an admin to delete another user's file", async () => {
+      const fileId = "admin-delete-member-file";
+      const { dbUtils, filePath } = await createFileFixture(fileId, memberUserId);
+
+      const res = await makeRequest(app, "DELETE", `/api/files/${fileId}`, {
+        cookie: adminCookie,
+      });
+
+      expect(res.status).toBe(200);
+      expect(dbUtils.getFileById(fileId)).toBeFalsy();
+      expect(await Bun.file(filePath).exists()).toBe(false);
+    });
+
+    it("denies a non-owner member without deleting disk content", async () => {
+      const fileId = "member-denied-admin-file";
+      const { dbUtils, filePath } = await createFileFixture(fileId, adminUserId);
+
+      const res = await makeRequest(app, "DELETE", `/api/files/${fileId}`, {
+        cookie: memberCookie,
+      });
+
+      expect([403, 404]).toContain(res.status);
+      expect(dbUtils.getFileById(fileId)).toBeTruthy();
+      expect(await Bun.file(filePath).exists()).toBe(true);
+    });
+  });
+
   describe("POST /api/files (upload)", () => {
     async function uploadFile(app, cookie, { name, type, content }) {
       const fd = new FormData();
@@ -319,6 +367,38 @@ describe("file routes", () => {
       expect(body.meta.attachmentCategory).toBe("textLike");
       expect(body.meta.normalizedMimeType).toBe("text/csv");
       expect(body.meta.downloadPolicy).toBe("inlineSafe");
+    });
+
+    it("removes the disk file when metadata insert fails", async () => {
+      const filename = `db-fail-${Date.now()}.txt`;
+      const triggerName = "files_test_fail_insert";
+      let leftovers = [];
+      db.exec(`
+        CREATE TRIGGER ${triggerName}
+        BEFORE INSERT ON files
+        WHEN NEW.filename = '${filename}'
+        BEGIN
+          SELECT RAISE(ABORT, 'test db failure');
+        END
+      `);
+
+      try {
+        const res = await uploadFile(app, adminCookie, {
+          name: filename,
+          type: "text/plain",
+          content: Buffer.from("orphan check"),
+        });
+        expect(res.status).toBe(500);
+        leftovers = (await readdir(FILE_CONFIG.UPLOAD_DIR)).filter((name) =>
+          name.endsWith(`_${filename}`)
+        );
+        expect(leftovers).toEqual([]);
+      } finally {
+        db.exec(`DROP TRIGGER IF EXISTS ${triggerName}`);
+        await Promise.all(
+          leftovers.map((name) => rm(path.join(FILE_CONFIG.UPLOAD_DIR, name), { force: true }))
+        );
+      }
     });
   });
 });

--- a/server/src/test/providers.test.js
+++ b/server/src/test/providers.test.js
@@ -9,6 +9,26 @@ import {
 } from "./helpers.js";
 import { dbUtils } from "../lib/db.js";
 
+const MODELS_DEV_TEST_DATABASE = {
+  openai: {
+    name: "OpenAI",
+    api: "https://api.openai.com/v1",
+    env: ["OPENAI_API_KEY"],
+    models: {
+      "gpt-4o": {
+        name: "GPT-4o",
+        modalities: { input: ["text"], output: ["text"] },
+      },
+    },
+  },
+  "z-community": {
+    name: "Z Community",
+    api: "https://api.z-community.example/v1",
+    env: ["Z_COMMUNITY_API_KEY"],
+    models: {},
+  },
+};
+
 // Stub DNS so tests using fictitious hostnames don't depend on real network resolution.
 // Returns a public-looking (TEST-NET-3) IP for any hostname.
 dns.promises.lookup = async (_hostname, opts) => {
@@ -19,14 +39,31 @@ dns.promises.lookup = async (_hostname, opts) => {
 
 describe("provider routes", () => {
   let app, adminCookie, memberCookie;
+  let originalFetch;
 
   beforeAll(async () => {
+    originalFetch = globalThis.fetch;
+    globalThis.fetch = async (input, init) => {
+      const url = typeof input === "string" ? input : input.url;
+      if (url === "https://models.dev/api.json") {
+        return new Response(JSON.stringify(MODELS_DEV_TEST_DATABASE), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      return originalFetch(input, init);
+    };
+
     resetDatabase();
     app = createTestApp();
     const admin = await seedAdminUser(app);
     adminCookie = admin.cookie;
     const member = await seedMemberUser(app, adminCookie);
     memberCookie = member.cookie;
+  });
+
+  afterAll(() => {
+    globalThis.fetch = originalFetch;
   });
 
   describe("access control", () => {
@@ -281,43 +318,27 @@ describe("provider routes", () => {
       expect(res.status).toBe(403);
     });
 
-    test("returns providers array for admin", async () => {
-      const originalFetch = globalThis.fetch;
-      globalThis.fetch = async (input, init) => {
-        if (typeof input === "string" && input === "https://models.dev/api.json") {
-          return new Response(
-            JSON.stringify({
-              openai: {
-                name: "OpenAI",
-                api: "https://api.openai.com/v1",
-                env: ["OPENAI_API_KEY"],
-                models: {
-                  "gpt-4o": {
-                    name: "GPT-4o",
-                    modalities: { input: ["text"], output: ["text"] },
-                  },
-                },
-              },
-            }),
-            {
-              status: 200,
-              headers: { "Content-Type": "application/json" },
-            }
-          );
-        }
-        return originalFetch(input, init);
-      };
-
+    test("returns providers array for admin in local, official, community order", async () => {
       const res = await makeRequest(app, "GET", "/api/admin/providers/available", {
         cookie: adminCookie,
-      }).finally(() => {
-        globalThis.fetch = originalFetch;
       });
       expect(res.status).toBe(200);
       const data = await res.json();
       expect(Array.isArray(data.providers)).toBe(true);
       expect(data.providers.length).toBeGreaterThan(0);
       expect(data.providers.some((provider) => provider.id === "openai")).toBe(true);
+      expect(data.providers.find((provider) => provider.id === "llama-cpp")?.category).toBe(
+        "local"
+      );
+      expect(data.providers.find((provider) => provider.id === "z-community")?.category).toBe(
+        "community"
+      );
+      const kinds = data.providers.map((provider) => {
+        const kind = provider.type ?? provider.category;
+        return kind === "openai-compatible" ? "local" : kind;
+      });
+      expect(kinds.lastIndexOf("local")).toBeLessThan(kinds.indexOf("official"));
+      expect(kinds.lastIndexOf("official")).toBeLessThan(kinds.indexOf("community"));
     });
   });
 


### PR DESCRIPTION
Fixes B1, B2, M1 + one minor from CODE-QUALITY-REVIEW.md (spec: specs/quality-review/spec-1-behavioral-fixes.md).

- **B1**: `DELETE /files/:id` now deletes the DB row first (unscoped by-id after `validateFileAccess`, which already handles admin), disk unlink is best-effort afterwards. Admin deleting another user's file no longer 500s with the content destroyed and the row orphaned. 404 on 0 rows, disk untouched. Removed now-unused `deleteFileByUser`.
- **B2**: provider sort comparator keyed on `type ?? category` with defined fallback — no more NaN comparisons; LOCAL→OFFICIAL→COMMUNITY order is deterministic again.
- **Minor**: provider create no longer silently swallows model-fetch failures (logs them).
- **M1**: upload route cleans up the just-written disk file when the DB insert throws (real path), dead `if (!fileRecord)` branch removed.

Tests: 409 pass (baseline 406 + 3 new: admin delete ordering, non-owner delete, provider ordering, upload orphan cleanup).

Adversarial review: opus APPROVE, gpt-5.5 APPROVE (0 findings).