### PR TITLE
refactor: message_files composite primary key (migration 005)

### DIFF
--- a/server/src/lib/db.js
+++ b/server/src/lib/db.js
@@ -100,7 +100,7 @@ Object.assign(
   createProviderUtils({ db, buildUpdateFields }),
   createModelUtils({ db, buildUpdateFields }),
   createFileUtils({ db, parseFileMeta }),
-  createChatUtils({ db, parseMessageMetadata, crypto }),
+  createChatUtils({ db, parseMessageMetadata }),
   createFolderUtils({ db, buildUpdateFields }),
   createSettingUtils({ db, encryptApiKey, decryptApiKey }),
   createAuditUtils({ db }),

--- a/server/src/lib/db/chats.js
+++ b/server/src/lib/db/chats.js
@@ -1,12 +1,12 @@
-export function createChatUtils({ db, parseMessageMetadata, crypto }) {
-  // Batch fetch file IDs for messages, ordered by created_at ASC
+export function createChatUtils({ db, parseMessageMetadata }) {
+  // Batch fetch file IDs for messages, ordered by created_at ASC, rowid ASC
   function getMessageFileIds(messageIds) {
     if (!messageIds || messageIds.length === 0) {
       return {};
     }
     const placeholders = messageIds.map(() => "?").join(",");
     const stmt = db.prepare(
-      `SELECT message_id, file_id FROM message_files WHERE message_id IN (${placeholders}) ORDER BY created_at ASC`
+      `SELECT message_id, file_id FROM message_files WHERE message_id IN (${placeholders}) ORDER BY created_at ASC, rowid ASC`
     );
     const rows = stmt.all(...messageIds);
 
@@ -29,7 +29,6 @@ export function createChatUtils({ db, parseMessageMetadata, crypto }) {
     const messageIds = messages.map((m) => m.id);
     const fileIdMap = getMessageFileIds(messageIds);
     for (const msg of messages) {
-      // Use empty array when there are no associations
       msg.file_ids = fileIdMap[msg.id] ?? null;
     }
     return messages;
@@ -200,10 +199,10 @@ export function createChatUtils({ db, parseMessageMetadata, crypto }) {
         // Insert junction rows for file associations - one per unique fileId
         if (fileIds && fileIds.length > 0) {
           const insertStmt = db.prepare(
-            "INSERT INTO message_files (id, message_id, file_id, created_at) VALUES (?, ?, ?, ?)"
+            "INSERT INTO message_files (message_id, file_id, created_at) VALUES (?, ?, ?)"
           );
           for (const fileId of new Set(fileIds)) {
-            insertStmt.run(crypto.randomUUID(), id, fileId, now);
+            insertStmt.run(id, fileId, now);
           }
         }
       })();

--- a/server/src/lib/db/chats.js
+++ b/server/src/lib/db/chats.js
@@ -250,9 +250,7 @@ export function createChatUtils({ db, parseMessageMetadata }) {
     },
 
     deleteMessageByUser(messageId, userId, chatId) {
-      const stmt = db.prepare(
-        "DELETE FROM messages WHERE id = ? AND user_id = ? AND chat_id = ?"
-      );
+      const stmt = db.prepare("DELETE FROM messages WHERE id = ? AND user_id = ? AND chat_id = ?");
       const result = stmt.run(messageId, userId, chatId);
       return result.changes > 0;
     },

--- a/server/src/lib/db/migrations/003_message_files_junction.js
+++ b/server/src/lib/db/migrations/003_message_files_junction.js
@@ -2,23 +2,18 @@ export const migration = {
   id: 3,
   up(database) {
     // Create the junction table with foreign keys and ON DELETE CASCADE
-    // Uses UUID primary key for consistency with the rest of the schema
     database.exec(`
       CREATE TABLE IF NOT EXISTS message_files (
-        id TEXT PRIMARY KEY,
         message_id TEXT NOT NULL,
         file_id TEXT NOT NULL,
         created_at INTEGER NOT NULL,
-        UNIQUE(message_id, file_id),
+        PRIMARY KEY (message_id, file_id),
         FOREIGN KEY (message_id) REFERENCES messages(id) ON DELETE CASCADE,
         FOREIGN KEY (file_id) REFERENCES files(id) ON DELETE CASCADE
       )
     `);
 
-    // Create indexes for efficient querying
-    database.exec(`
-      CREATE INDEX IF NOT EXISTS idx_message_files_message_id ON message_files(message_id)
-    `);
+    // Create index for file delete paths
     database.exec(`
       CREATE INDEX IF NOT EXISTS idx_message_files_file_id ON message_files(file_id)
     `);
@@ -66,7 +61,7 @@ export const migration = {
     // Batch insert all valid junction rows
     const now = Date.now();
     const insertStmt = database.prepare(
-      "INSERT OR IGNORE INTO message_files (id, message_id, file_id, created_at) VALUES (?, ?, ?, ?)"
+      "INSERT OR IGNORE INTO message_files (message_id, file_id, created_at) VALUES (?, ?, ?)"
     );
 
     database.transaction(() => {
@@ -86,9 +81,7 @@ export const migration = {
         for (const fileId of fileIds) {
           // Only insert if the file actually exists (skip orphans)
           if (existingFileIds.has(fileId)) {
-            // Generate UUID for the junction row
-            const junctionId = crypto.randomUUID();
-            insertStmt.run(junctionId, msg.id, fileId, now);
+            insertStmt.run(msg.id, fileId, now);
           }
         }
       }

--- a/server/src/lib/db/migrations/004_backfill_message_files_id.js
+++ b/server/src/lib/db/migrations/004_backfill_message_files_id.js
@@ -1,17 +1,4 @@
 export const migration = {
   id: 4,
-  up(database) {
-    // Repair junction rows written by the buggy insert that omitted the id
-    // (TEXT PRIMARY KEY accepts NULL, so these slipped in unkeyed).
-    const rows = database.prepare("SELECT rowid FROM message_files WHERE id IS NULL").all();
-    if (rows.length === 0) {
-      return;
-    }
-    const update = database.prepare("UPDATE message_files SET id = ? WHERE rowid = ?");
-    database.transaction(() => {
-      for (const row of rows) {
-        update.run(crypto.randomUUID(), row.rowid);
-      }
-    })();
-  },
+  up() {},
 };

--- a/server/src/lib/db/migrations/005_message_files_composite_pk.js
+++ b/server/src/lib/db/migrations/005_message_files_composite_pk.js
@@ -1,0 +1,37 @@
+export const migration = {
+  id: 5,
+  up(database) {
+    const columns = database.prepare("PRAGMA table_info(message_files)").all();
+    if (columns.length === 0) {
+      return;
+    }
+
+    database.exec(`
+      CREATE TABLE message_files_new (
+        message_id TEXT NOT NULL,
+        file_id TEXT NOT NULL,
+        created_at INTEGER NOT NULL,
+        PRIMARY KEY (message_id, file_id),
+        FOREIGN KEY (message_id) REFERENCES messages(id) ON DELETE CASCADE,
+        FOREIGN KEY (file_id) REFERENCES files(id) ON DELETE CASCADE
+      );
+
+      INSERT INTO message_files_new (message_id, file_id, created_at)
+      SELECT mf.message_id, mf.file_id, mf.created_at
+      FROM message_files mf
+      WHERE mf.rowid = (
+        SELECT candidate.rowid
+        FROM message_files candidate
+        WHERE candidate.message_id = mf.message_id
+          AND candidate.file_id = mf.file_id
+        ORDER BY candidate.created_at ASC, candidate.rowid ASC
+        LIMIT 1
+      )
+      ORDER BY mf.rowid ASC;
+
+      DROP TABLE message_files;
+      ALTER TABLE message_files_new RENAME TO message_files;
+      CREATE INDEX IF NOT EXISTS idx_message_files_file_id ON message_files(file_id);
+    `);
+  },
+};

--- a/server/src/lib/db/migrations/index.js
+++ b/server/src/lib/db/migrations/index.js
@@ -2,10 +2,12 @@ import { migration as initialSchema } from "./001_initial_schema.js";
 import { migration as addExistingColumns } from "./002_add_existing_columns.js";
 import { migration as messageFilesJunction } from "./003_message_files_junction.js";
 import { migration as backfillMessageFilesId } from "./004_backfill_message_files_id.js";
+import { migration as messageFilesCompositePk } from "./005_message_files_composite_pk.js";
 
 export const migrations = [
   initialSchema,
   addExistingColumns,
   messageFilesJunction,
   backfillMessageFilesId,
+  messageFilesCompositePk,
 ];

--- a/server/src/test/db.message-files.test.js
+++ b/server/src/test/db.message-files.test.js
@@ -713,15 +713,12 @@ describe("migration 005 message_files composite primary key", () => {
       Date.now = () => now;
       createMigrationBaseTables(freshDb, true);
       seedFilesAndMessages(freshDb, true);
-      const { migration: migration003 } = await import(
-        "../lib/db/migrations/003_message_files_junction.js"
-      );
-      const { migration: migration004 } = await import(
-        "../lib/db/migrations/004_backfill_message_files_id.js"
-      );
-      const { migration: migration005 } = await import(
-        "../lib/db/migrations/005_message_files_composite_pk.js"
-      );
+      const { migration: migration003 } =
+        await import("../lib/db/migrations/003_message_files_junction.js");
+      const { migration: migration004 } =
+        await import("../lib/db/migrations/004_backfill_message_files_id.js");
+      const { migration: migration005 } =
+        await import("../lib/db/migrations/005_message_files_composite_pk.js");
       migration003.up(freshDb);
       migration004.up(freshDb);
       migration005.up(freshDb);

--- a/server/src/test/db.message-files.test.js
+++ b/server/src/test/db.message-files.test.js
@@ -4,6 +4,82 @@ const { createTestApp, resetDatabase, seedAdminUser, makeRequest, db } =
 const { dbUtils } = await import("../lib/db.js");
 const { encryptApiKey } = await import("../lib/encryption.js");
 
+async function createMemoryDb() {
+  const { Database } = await import("bun:sqlite");
+  const database = new Database(":memory:");
+  database.exec("PRAGMA foreign_keys = ON");
+  return database;
+}
+
+function expectCompositeMessageFilesSchema(database) {
+  const columns = database.prepare("PRAGMA table_info(message_files)").all();
+  expect(columns.map((column) => column.name)).toEqual(["message_id", "file_id", "created_at"]);
+  expect(columns.find((column) => column.name === "message_id").pk).toBe(1);
+  expect(columns.find((column) => column.name === "file_id").pk).toBe(2);
+
+  const indexes = database.prepare("PRAGMA index_list(message_files)").all();
+  expect(indexes.some((index) => index.name === "idx_message_files_message_id")).toBe(false);
+  expect(indexes.some((index) => index.name === "idx_message_files_file_id")).toBe(true);
+  expect(indexes.some((index) => index.origin === "u")).toBe(false);
+
+  const foreignKeys = database
+    .prepare("PRAGMA foreign_key_list(message_files)")
+    .all()
+    .map((fk) => ({
+      table: fk.table,
+      from: fk.from,
+      to: fk.to,
+      on_delete: fk.on_delete,
+    }))
+    .sort((a, b) => a.from.localeCompare(b.from));
+  expect(foreignKeys).toEqual([
+    { table: "files", from: "file_id", to: "id", on_delete: "CASCADE" },
+    { table: "messages", from: "message_id", to: "id", on_delete: "CASCADE" },
+  ]);
+
+  expect(() => database.prepare("SELECT rowid FROM message_files LIMIT 1").all()).not.toThrow();
+}
+
+function normalizedMessageFilesSchema(database) {
+  return {
+    columns: database
+      .prepare("PRAGMA table_info(message_files)")
+      .all()
+      .map((column) => ({
+        name: column.name,
+        type: column.type,
+        notnull: column.notnull,
+        pk: column.pk,
+      })),
+    indexes: database
+      .prepare("PRAGMA index_list(message_files)")
+      .all()
+      .map((index) => ({
+        name: index.name.startsWith("sqlite_autoindex") ? "sqlite_autoindex" : index.name,
+        unique: index.unique,
+        origin: index.origin,
+        partial: index.partial,
+      }))
+      .sort((a, b) => a.name.localeCompare(b.name)),
+    foreignKeys: database
+      .prepare("PRAGMA foreign_key_list(message_files)")
+      .all()
+      .map((fk) => ({
+        table: fk.table,
+        from: fk.from,
+        to: fk.to,
+        on_delete: fk.on_delete,
+      }))
+      .sort((a, b) => a.from.localeCompare(b.from)),
+  };
+}
+
+function messageFilesData(database) {
+  return database
+    .prepare("SELECT message_id, file_id, created_at FROM message_files ORDER BY message_id, rowid")
+    .all();
+}
+
 describe("message_files junction table", () => {
   let app, adminCookie, adminUserId, chatId, fileId1, fileId2;
 
@@ -80,6 +156,46 @@ describe("message_files junction table", () => {
     const fileIds = rows.map((r) => r.file_id);
     expect(fileIds).toContain(fileId1);
     expect(fileIds).toContain(fileId2);
+  });
+
+  test("message_files rejects duplicate message and file pairs", async () => {
+    const freshFile = await createTestFile(adminUserId, "duplicate-pair.txt");
+    const res = await makeRequest(app, "POST", `/api/chats/${chatId}/messages`, {
+      body: {
+        role: "user",
+        content: "Duplicate pair test",
+        fileIds: [freshFile],
+      },
+      cookie: adminCookie,
+    });
+
+    expect(res.status).toBe(201);
+    const msg = await res.json();
+
+    const duplicateInsert = db.prepare(
+      "INSERT INTO message_files (message_id, file_id, created_at) VALUES (?, ?, ?)"
+    );
+    expect(() => {
+      duplicateInsert.run(msg.id, freshFile, Date.now());
+    }).toThrow();
+  });
+
+  test("getMessageById returns fileIds in insertion order when timestamps match", async () => {
+    const firstFile = await createTestFile(adminUserId, "ordered-first.txt");
+    const secondFile = await createTestFile(adminUserId, "ordered-second.txt");
+    const res = await makeRequest(app, "POST", `/api/chats/${chatId}/messages`, {
+      body: {
+        role: "user",
+        content: "Attachment order test",
+        fileIds: [secondFile, firstFile],
+      },
+      cookie: adminCookie,
+    });
+
+    expect(res.status).toBe(201);
+    const msg = await res.json();
+    const dbMsg = dbUtils.getMessageById(msg.id);
+    expect(dbMsg.file_ids).toEqual([secondFile, firstFile]);
   });
 
   test("createMessage with empty fileIds creates no junction entries", async () => {
@@ -516,6 +632,7 @@ describe("migration 003 backfill", () => {
     expect(junctionTableInfo.map((c) => c.name)).toContain("message_id");
     expect(junctionTableInfo.map((c) => c.name)).toContain("file_id");
     expect(junctionTableInfo.map((c) => c.name)).toContain("created_at");
+    expectCompositeMessageFilesSchema(testDb);
 
     // Verify: valid file association was migrated (only existingFileId, orphan skipped)
     const junctionRows = testDb
@@ -544,12 +661,132 @@ describe("migration 003 backfill", () => {
 
     // Verify: UNIQUE constraint works (re-inserting same association should fail or be ignored)
     const duplicateInsert = testDb.prepare(
-      "INSERT INTO message_files (id, message_id, file_id, created_at) VALUES (?, ?, ?, ?)"
+      "INSERT INTO message_files (message_id, file_id, created_at) VALUES (?, ?, ?)"
     );
     expect(() => {
-      duplicateInsert.run(crypto.randomUUID(), messageId, existingFileId, Date.now());
+      duplicateInsert.run(messageId, existingFileId, Date.now());
     }).toThrow();
 
+    testDb.close();
+  });
+});
+
+describe("migration 005 message_files composite primary key", () => {
+  function createMigrationBaseTables(database, withFileIdsColumn) {
+    database.exec(`
+      CREATE TABLE messages (
+        id TEXT PRIMARY KEY${withFileIdsColumn ? ",\n        file_ids TEXT" : ""}
+      );
+
+      CREATE TABLE files (
+        id TEXT PRIMARY KEY
+      );
+    `);
+  }
+
+  function seedFilesAndMessages(database, withFileIdsColumn) {
+    database.prepare("INSERT INTO files (id) VALUES (?)").run("file-a");
+    database.prepare("INSERT INTO files (id) VALUES (?)").run("file-b");
+    database.prepare("INSERT INTO files (id) VALUES (?)").run("file-c");
+
+    if (withFileIdsColumn) {
+      database
+        .prepare("INSERT INTO messages (id, file_ids) VALUES (?, ?)")
+        .run("message-1", JSON.stringify(["file-b", "file-a", "file-b"]));
+      database
+        .prepare("INSERT INTO messages (id, file_ids) VALUES (?, ?)")
+        .run("message-2", JSON.stringify(["file-c"]));
+      return;
+    }
+
+    database.prepare("INSERT INTO messages (id) VALUES (?)").run("message-1");
+    database.prepare("INSERT INTO messages (id) VALUES (?)").run("message-2");
+  }
+
+  test("fresh and upgraded databases end with matching schema and data", async () => {
+    const freshDb = await createMemoryDb();
+    const upgradedDb = await createMemoryDb();
+    const now = 123456789;
+    const originalNow = Date.now;
+
+    try {
+      Date.now = () => now;
+      createMigrationBaseTables(freshDb, true);
+      seedFilesAndMessages(freshDb, true);
+      const { migration: migration003 } = await import(
+        "../lib/db/migrations/003_message_files_junction.js"
+      );
+      const { migration: migration004 } = await import(
+        "../lib/db/migrations/004_backfill_message_files_id.js"
+      );
+      const { migration: migration005 } = await import(
+        "../lib/db/migrations/005_message_files_composite_pk.js"
+      );
+      migration003.up(freshDb);
+      migration004.up(freshDb);
+      migration005.up(freshDb);
+
+      createMigrationBaseTables(upgradedDb, false);
+      seedFilesAndMessages(upgradedDb, false);
+      upgradedDb.exec(`
+        CREATE TABLE message_files (
+          id TEXT PRIMARY KEY,
+          message_id TEXT NOT NULL,
+          file_id TEXT NOT NULL,
+          created_at INTEGER NOT NULL,
+          UNIQUE(message_id, file_id),
+          FOREIGN KEY (message_id) REFERENCES messages(id) ON DELETE CASCADE,
+          FOREIGN KEY (file_id) REFERENCES files(id) ON DELETE CASCADE
+        );
+        CREATE INDEX idx_message_files_message_id ON message_files(message_id);
+        CREATE INDEX idx_message_files_file_id ON message_files(file_id);
+      `);
+      const insertLegacyRow = upgradedDb.prepare("INSERT INTO message_files VALUES (?, ?, ?, ?)");
+      insertLegacyRow.run("junction-1", "message-1", "file-b", now);
+      insertLegacyRow.run("junction-2", "message-1", "file-a", now);
+      insertLegacyRow.run("junction-3", "message-2", "file-c", now);
+      migration005.up(upgradedDb);
+
+      expectCompositeMessageFilesSchema(freshDb);
+      expectCompositeMessageFilesSchema(upgradedDb);
+      expect(normalizedMessageFilesSchema(freshDb)).toEqual(
+        normalizedMessageFilesSchema(upgradedDb)
+      );
+      expect(messageFilesData(freshDb)).toEqual(messageFilesData(upgradedDb));
+    } finally {
+      Date.now = originalNow;
+      freshDb.close();
+      upgradedDb.close();
+    }
+  });
+
+  test("dedupes duplicate pairs by earliest timestamp during rebuild", async () => {
+    const testDb = await createMemoryDb();
+    createMigrationBaseTables(testDb, false);
+    seedFilesAndMessages(testDb, false);
+    testDb.exec(`
+      CREATE TABLE message_files (
+        id TEXT PRIMARY KEY,
+        message_id TEXT NOT NULL,
+        file_id TEXT NOT NULL,
+        created_at INTEGER NOT NULL,
+        FOREIGN KEY (message_id) REFERENCES messages(id) ON DELETE CASCADE,
+        FOREIGN KEY (file_id) REFERENCES files(id) ON DELETE CASCADE
+      );
+    `);
+    const insertLegacyRow = testDb.prepare("INSERT INTO message_files VALUES (?, ?, ?, ?)");
+    insertLegacyRow.run("junction-late", "message-1", "file-a", 20);
+    insertLegacyRow.run("junction-early", "message-1", "file-a", 10);
+    insertLegacyRow.run("junction-other", "message-1", "file-b", 15);
+
+    const { migration } = await import("../lib/db/migrations/005_message_files_composite_pk.js");
+    migration.up(testDb);
+
+    expectCompositeMessageFilesSchema(testDb);
+    expect(messageFilesData(testDb)).toEqual([
+      { message_id: "message-1", file_id: "file-a", created_at: 10 },
+      { message_id: "message-1", file_id: "file-b", created_at: 15 },
+    ]);
     testDb.close();
   });
 });


### PR DESCRIPTION
Fixes B4 from CODE-QUALITY-REVIEW.md (spec: specs/quality-review/spec-3-composite-pk.md).

- Migration 005 rebuilds `message_files` with `PRIMARY KEY (message_id, file_id)`: drops the NULLable surrogate `id` TEXT PK (which already shipped one bug that 004 existed to repair), the now-redundant `UNIQUE(message_id, file_id)`, and `idx_message_files_message_id` (covered by the PK's left prefix). Keeps `idx_message_files_file_id`. Data preserved with deterministic dedupe (earliest `created_at`, rowid tiebreak).
- Migration 003 now creates the final schema directly on fresh installs; 004 is a no-op (runner records applied migrations by id, so already-migrated DBs are unaffected; 005 handles both lineages — verified by tests that build a real legacy id-column DB and assert PRAGMA-level schema+data convergence with the fresh path).
- All junction `crypto.randomUUID()` id generation removed, along with the orphaned `crypto` factory injection.
- Attachment ordering now explicit: `ORDER BY created_at ASC, rowid ASC`; removed a wrong comment about the `?? null` contract.

Tests: 410 pass (baseline 406 + duplicate-pair rejection, stable insertion order, fresh-vs-upgraded schema convergence, dedupe).

Adversarial review: opus APPROVE, gpt-5.5 APPROVE (gpt-5.5 executed both migration lineages against scratch DBs and diffed sqlite_master: equal).