### PR TITLE
fix: parse structured attachment errors in chat error path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,3 +72,6 @@ jobs:
         env:
           API_KEY_ENCRYPTION_KEY: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
         run: cd server && bun test
+
+      - name: Run frontend tests
+        run: bun run test:frontend

--- a/frontend/src/components/ui/ErrorBanner.jsx
+++ b/frontend/src/components/ui/ErrorBanner.jsx
@@ -14,7 +14,7 @@ const ErrorBanner = ({ message, className = "", onDismiss }) => {
       <div className="flex items-start gap-3">
         <div className="flex-1">
           <p className="font-medium">Something went wrong</p>
-          <p className="text-theme-red/80 mt-1">{text}</p>
+          <p className="text-theme-red/80 mt-1 whitespace-pre-line">{text}</p>
         </div>
         {onDismiss && (
           <button

--- a/frontend/src/lib/errorHandler.js
+++ b/frontend/src/lib/errorHandler.js
@@ -14,19 +14,17 @@ export function extractErrorMessage(error) {
     return extractFromString(error.message);
   }
   if (typeof error === "object") {
-    return extractFromObject(error);
+    return extractFromObject(error) ?? safeString(error);
   }
 
-  try {
-    return String(error);
-  } catch {
-    return "An unexpected error occurred.";
-  }
+  return safeString(error);
 }
 
 // A serialized structured error can arrive as a raw JSON string (e.g. the AI SDK
-// transport throws `new Error(await response.text())`). Parse it back into the
-// structured-object handling; non-JSON strings pass through unchanged.
+// transport throws `new Error(await response.text())`). Parsing may only improve
+// the message, never degrade it: only plain objects that yield a usable message
+// get reformatted; arrays, non-objects, and objects with no extractable message
+// pass through as the original string unchanged.
 function extractFromString(str) {
   let parsed;
   try {
@@ -34,9 +32,13 @@ function extractFromString(str) {
   } catch {
     return str;
   }
-  return parsed && typeof parsed === "object" ? extractFromObject(parsed) : str;
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    return str;
+  }
+  return extractFromObject(parsed) ?? str;
 }
 
+// Returns a usable message string, or null when nothing extractable is present.
 function extractFromObject(error) {
   // Check for structured attachment error with code and details
   if (error.code && error.details) {
@@ -54,8 +56,12 @@ function extractFromObject(error) {
     return error.error.message;
   }
 
+  return null;
+}
+
+function safeString(value) {
   try {
-    return String(error);
+    return String(value);
   } catch {
     return "An unexpected error occurred.";
   }

--- a/frontend/src/lib/errorHandler.js
+++ b/frontend/src/lib/errorHandler.js
@@ -8,27 +8,50 @@ export function extractErrorMessage(error) {
     return "An unexpected error occurred.";
   }
   if (typeof error === "string") {
-    return error;
+    return extractFromString(error);
   }
   if (error instanceof Error) {
-    return error.message;
+    return extractFromString(error.message);
   }
   if (typeof error === "object") {
-    // Check for structured attachment error with code and details
-    if (error.code && error.details) {
-      const detailsText = formatErrorDetails(error.details);
-      return detailsText || error.error || error.message || "Attachment error";
-    }
+    return extractFromObject(error);
+  }
 
-    if (typeof error.message === "string") {
-      return error.message;
-    }
-    if (typeof error.error === "string") {
-      return error.error;
-    }
-    if (error.error && typeof error.error.message === "string") {
-      return error.error.message;
-    }
+  try {
+    return String(error);
+  } catch {
+    return "An unexpected error occurred.";
+  }
+}
+
+// A serialized structured error can arrive as a raw JSON string (e.g. the AI SDK
+// transport throws `new Error(await response.text())`). Parse it back into the
+// structured-object handling; non-JSON strings pass through unchanged.
+function extractFromString(str) {
+  let parsed;
+  try {
+    parsed = JSON.parse(str);
+  } catch {
+    return str;
+  }
+  return parsed && typeof parsed === "object" ? extractFromObject(parsed) : str;
+}
+
+function extractFromObject(error) {
+  // Check for structured attachment error with code and details
+  if (error.code && error.details) {
+    const detailsText = formatErrorDetails(error.details);
+    return detailsText || error.error || error.message || "Attachment error";
+  }
+
+  if (typeof error.message === "string") {
+    return error.message;
+  }
+  if (typeof error.error === "string") {
+    return error.error;
+  }
+  if (error.error && typeof error.error.message === "string") {
+    return error.error.message;
   }
 
   try {

--- a/frontend/src/lib/errorHandler.test.js
+++ b/frontend/src/lib/errorHandler.test.js
@@ -60,4 +60,21 @@ describe("extractErrorMessage", () => {
   test("JSON string of a non-object -> passthrough", () => {
     expect(extractErrorMessage("42")).toBe("42");
   });
+
+  test("JSON empty array -> passthrough (banner-visible original string)", () => {
+    expect(extractErrorMessage("[]")).toBe("[]");
+  });
+
+  test("JSON array -> passthrough", () => {
+    expect(extractErrorMessage("[1,2]")).toBe("[1,2]");
+  });
+
+  test("JSON empty object -> passthrough", () => {
+    expect(extractErrorMessage("{}")).toBe("{}");
+  });
+
+  test("unrecognized object shape -> passthrough of original JSON string", () => {
+    const raw = '{"detail":"Rate limited"}';
+    expect(extractErrorMessage(raw)).toBe(raw);
+  });
 });

--- a/frontend/src/lib/errorHandler.test.js
+++ b/frontend/src/lib/errorHandler.test.js
@@ -1,0 +1,63 @@
+import { describe, test, expect } from "vitest";
+import { extractErrorMessage } from "@/lib/errorHandler";
+
+describe("extractErrorMessage", () => {
+  test("raw JSON string with {code, error, details} -> formatted human message", () => {
+    const raw = JSON.stringify({
+      code: "ATTACHMENT_PROVIDER_UNSUPPORTED",
+      error: "One or more attachments are not supported by the selected model.",
+      details: [
+        {
+          filename: "report.pdf",
+          reason: "This model does not support PDFs.",
+          suggestion: "Try a model that supports PDFs.",
+        },
+      ],
+    });
+    const msg = extractErrorMessage(raw);
+    expect(msg).toBe(
+      '- "report.pdf": This model does not support PDFs. (Try a model that supports PDFs.)'
+    );
+    expect(msg).not.toContain("{");
+    expect(msg).not.toContain("code");
+  });
+
+  test("multiple details render as newline-separated lines", () => {
+    const raw = JSON.stringify({
+      code: "ATTACHMENT_UNSUPPORTED",
+      error: "unsupported",
+      details: [
+        { filename: "a.pdf", reason: "no pdf", suggestion: "" },
+        { filename: "b.doc", reason: "no doc", suggestion: "" },
+      ],
+    });
+    const msg = extractErrorMessage(raw);
+    expect(msg).toContain("\n");
+    expect(msg).toContain('"a.pdf"');
+    expect(msg).toContain('"b.doc"');
+  });
+
+  test("plain string -> passthrough", () => {
+    expect(extractErrorMessage("Something broke")).toBe("Something broke");
+  });
+
+  test("malformed JSON -> passthrough, does not throw", () => {
+    const bad = '{"code":"X","details":';
+    expect(extractErrorMessage(bad)).toBe(bad);
+  });
+
+  test("Error whose message is structured JSON -> formatted", () => {
+    const raw = JSON.stringify({
+      code: "ATTACHMENT_UNSUPPORTED",
+      error: "unsupported",
+      details: [{ filename: "x.doc", reason: "not supported", suggestion: "" }],
+    });
+    const msg = extractErrorMessage(new Error(raw));
+    expect(msg).toBe('- "x.doc": not supported ');
+    expect(msg).not.toContain("code");
+  });
+
+  test("JSON string of a non-object -> passthrough", () => {
+    expect(extractErrorMessage("42")).toBe("42");
+  });
+});

--- a/server/src/test/chats.completion.test.js
+++ b/server/src/test/chats.completion.test.js
@@ -525,6 +525,11 @@ describe("chat completion - Phase 4 PDF preflight", () => {
 
     expect(res.status).toBe(400);
     const body = await res.json();
+    // Client parser (extractErrorMessage) depends on this {code, error, details} shape.
+    expect(typeof body.code).toBe("string");
+    expect(typeof body.error).toBe("string");
+    expect(Array.isArray(body.details)).toBe(true);
+    expect(body.code).toBe("ATTACHMENT_PROVIDER_UNSUPPORTED");
     expect(body.error).toBe("One or more attachments are not supported by the selected model.");
     expect(body.details).toHaveLength(1);
     expect(body.details[0].filename).toBe("report.pdf");


### PR DESCRIPTION
Fixes B3 from CODE-QUALITY-REVIEW.md (spec: specs/quality-review/spec-2-attachment-error-display.md).

- `extractErrorMessage`'s string path now `JSON.parse`s serialized structured errors — the AI SDK v6 transport throws `new Error(await response.text())`, so the completion preflight's `{code, error, details}` body reached the ErrorBanner as literal JSON text. Parsed objects route through the existing structured formatting (shared, not duplicated).
- Guardrail from adversarial review: parsing may only improve the message, never degrade it — arrays, non-objects, and objects with no extractable message pass through as the original string (previously the fix coerced `'[]'` to `''`, suppressing the banner, and unrecognized objects to `'[object Object]'`).
- ErrorBanner renders multi-line `formatErrorDetails` output (`whitespace-pre-line`).
- CI now runs the frontend suite (`bun run test:frontend`) — the new parser tests otherwise never fire on PRs.

Tests: server 406 pass; frontend 36 pass (10 new parser cases incl. passthrough guards); server preflight test now asserts the full `{code, error, details}` body shape.

Adversarial review: opus APPROVE, gpt-5.5 REQUEST-CHANGES (array/unrecognized-object coercion) → fixed, both findings covered by new tests.