### PR TITLE
refactor: single upload error channel, derive fileIds at submit

### DIFF
--- a/frontend/src/components/chat/ChatInterface.jsx
+++ b/frontend/src/components/chat/ChatInterface.jsx
@@ -79,7 +79,7 @@ const ChatInterface = ({ chatId }) => {
     isLoading,
     status,
     stop,
-    regenerateResponse,
+    regenerate,
     setInput,
   } = useChat({
     id: chatId,
@@ -187,7 +187,7 @@ const ChatInterface = ({ chatId }) => {
               isGeneratingImage={isGenerating}
               status={status}
               onStop={stop}
-              onRegenerate={regenerateResponse}
+              onRegenerate={regenerate}
             />
           </div>
         </div>

--- a/frontend/src/components/chat/FilePreviewList.jsx
+++ b/frontend/src/components/chat/FilePreviewList.jsx
@@ -6,8 +6,6 @@ const CATEGORY_LABELS = {
   [FILE_CATEGORIES.PDF]: "PDF",
   [FILE_CATEGORIES.TEXT_LIKE]: "Text",
   [FILE_CATEGORIES.OFFICE_MODERN]: "Office",
-  [FILE_CATEGORIES.OFFICE_LEGACY]: "Office",
-  [FILE_CATEGORIES.UNKNOWN_BINARY]: "File",
 };
 
 export function FilePreviewList({ files, onRemove }) {

--- a/frontend/src/components/chat/InputArea.jsx
+++ b/frontend/src/components/chat/InputArea.jsx
@@ -1,12 +1,6 @@
-import { useRef, useState, useEffect } from "preact/hooks";
-import {
-  UI_CONSTANTS,
-  FILE_CONSTANTS,
-  ATTACHMENT_INPUT_ACCEPT,
-  ATTACHMENT_TITLE_TEXT,
-} from "@faster-chat/shared";
+import { useRef, useEffect } from "preact/hooks";
+import { UI_CONSTANTS, ATTACHMENT_INPUT_ACCEPT, ATTACHMENT_TITLE_TEXT } from "@faster-chat/shared";
 import { Paperclip, Image, Globe, Send, Mic, MicOff } from "lucide-preact";
-import ErrorBanner from "@/components/ui/ErrorBanner";
 import ChatMemoryButton from "./ChatMemoryButton";
 import { useFileUploader } from "@/hooks/useFileUploader";
 import { useFileDragDrop } from "@/hooks/useFileDragDrop";
@@ -33,24 +27,8 @@ const InputArea = ({
   isGenerating,
 }) => {
   const textareaRef = useRef(null);
-  const errorTimerRef = useRef(null);
-  const [uploadError, setUploadError] = useState(null);
-  const showUploadError = (msg) => {
-    clearTimeout(errorTimerRef.current);
-    setUploadError(msg);
-    if (msg) {
-      errorTimerRef.current = setTimeout(
-        () => setUploadError(null),
-        FILE_CONSTANTS.ERROR_DISPLAY_DURATION_MS
-      );
-    }
-  };
   const { uploadFiles, uploading, currentFile } = useFileUploader({
-    onFilesUploaded: (files) => {
-      onFilesUploaded(files);
-      showUploadError(null);
-    },
-    onError: showUploadError,
+    onFilesUploaded,
   });
   const { dragActive, handleDrag, handleDrop } = useFileDragDrop((files) => uploadFiles(files));
   const imageMode = useUiState((state) => state.imageMode);
@@ -124,16 +102,12 @@ const InputArea = ({
       return;
     }
 
-    const fileIds = selectedFiles.map((f) => f.id);
-    handleSubmit(e, fileIds);
+    handleSubmit(e);
 
     // Reset textarea height when clearing input
     if (textareaRef.current) {
       textareaRef.current.style.height = "auto";
     }
-
-    // Clear upload error (files will be cleared by parent on success)
-    showUploadError(null);
   };
 
   const handleFileChange = (e) => {
@@ -179,8 +153,6 @@ const InputArea = ({
         {uploading && currentFile && (
           <div className="text-theme-text-muted mb-2 text-xs">Uploading {currentFile}...</div>
         )}
-
-        <ErrorBanner message={uploadError} className="mb-2" />
 
         {!imageMode && <FilePreviewList files={selectedFiles} onRemove={onRemoveFile} />}
 

--- a/frontend/src/components/chat/InputArea.test.jsx
+++ b/frontend/src/components/chat/InputArea.test.jsx
@@ -44,10 +44,6 @@ vi.mock("@/components/chat/ChatMemoryButton", () => ({
   default: () => <div data-testid="memory-button" />,
 }));
 
-vi.mock("@/components/ui/ErrorBanner", () => ({
-  default: () => null,
-}));
-
 vi.mock("@/components/chat/FilePreviewList", () => ({
   FilePreviewList: () => <div data-testid="file-preview-list" />,
 }));

--- a/frontend/src/hooks/useChat.js
+++ b/frontend/src/hooks/useChat.js
@@ -37,6 +37,7 @@ export function useChat({ id: chatId, model, webSearchEnabled, memoryEnabled }) 
     const messageId = crypto.randomUUID();
     const createdAt = Date.now();
     setInput("");
+    setInputFiles([]);
     stream.clearError();
 
     try {
@@ -45,15 +46,14 @@ export function useChat({ id: chatId, model, webSearchEnabled, memoryEnabled }) 
         chatId
       );
       await stream.send({ id: messageId, content: trimmedContent, fileIds, createdAt });
-      setInputFiles([]);
     } catch (err) {
       console.error("Failed to send message", err);
     }
   }
 
-  function handleSubmit(e, fileIds = []) {
+  function handleSubmit(e) {
     e.preventDefault();
-    submitMessage({ content: input, fileIds });
+    submitMessage({ content: input, fileIds: inputFiles.map((f) => f.id) });
   }
 
   function handleInputChange(e) {
@@ -61,10 +61,6 @@ export function useChat({ id: chatId, model, webSearchEnabled, memoryEnabled }) 
   }
 
   const isLoading = (chatId && isChatLoading) || stream.isStreaming;
-
-  async function regenerateResponse() {
-    stream.reload();
-  }
 
   const appendFiles = (files) => setInputFiles((prev) => [...prev, ...files]);
   const removeFile = (fileId) => setInputFiles((prev) => prev.filter((f) => f.id !== fileId));
@@ -85,7 +81,7 @@ export function useChat({ id: chatId, model, webSearchEnabled, memoryEnabled }) 
     clearError: stream.clearError,
     currentChat: chat,
     stop: stream.stop,
-    regenerateResponse: stream.isStreaming ? undefined : regenerateResponse,
+    regenerate: stream.isStreaming ? undefined : stream.regenerate,
     status: stream.status,
   };
 }

--- a/frontend/src/hooks/useChatStream.js
+++ b/frontend/src/hooks/useChatStream.js
@@ -140,7 +140,7 @@ export function useChatStream({
   return {
     messages,
     send,
-    reload: regenerate,
+    regenerate,
     stop,
     status,
     error,

--- a/frontend/src/hooks/useFileUploader.js
+++ b/frontend/src/hooks/useFileUploader.js
@@ -18,7 +18,7 @@ async function uploadFile(file) {
   return response.json();
 }
 
-export function useFileUploader({ onFilesUploaded, onError } = {}) {
+export function useFileUploader({ onFilesUploaded } = {}) {
   const [uploading, setUploading] = useState(false);
   const [currentFile, setCurrentFile] = useState(null);
 
@@ -39,7 +39,6 @@ export function useFileUploader({ onFilesUploaded, onError } = {}) {
 
     if (uploadable.length === 0) {
       if (errors.length > 0) {
-        onError?.(errors.join("\n"));
         toast.error("Upload failed", { description: errors[0] });
       }
       return;
@@ -66,7 +65,6 @@ export function useFileUploader({ onFilesUploaded, onError } = {}) {
       toast.success(uploaded.length === 1 ? "File uploaded" : `${uploaded.length} files uploaded`);
     }
     if (errors.length > 0) {
-      onError?.(errors.join("\n"));
       toast.error("Upload failed", { description: errors[0] });
     }
   }


### PR DESCRIPTION
Fixes M10, M11 + frontend minors from CODE-QUALITY-REVIEW.md (spec: specs/quality-review/spec-7-frontend-flow.md).

- **M10**: upload errors surfaced twice (toast in `useFileUploader` AND an ErrorBanner state machine in `InputArea` whose auto-dismiss timer was never cleaned up on unmount). Banner path deleted — `uploadError` state, timer ref, dismiss effect, render — toast is the single channel. Follow-up from review: the now-dead `onError` seam in `useFileUploader` deleted too, so the second channel can't quietly come back.
- **M11**: `handleSubmit(e)` derives fileIds internally from `inputFiles` (captured before the optimistic clear — reviewer-verified ordering); the `selectedFiles`→ids→parameter round-trip is gone.
- Draft text and file chips now clear together optimistically at send (chips no longer linger through the whole assistant stream; mid-stream errors can't duplicate attachments on resubmit).
- `regenerateResponse`→`reload`→`regenerate` double-rename collapsed to the SDK's `regenerate` end-to-end.
- Dead `CATEGORY_LABELS` entries removed from `FilePreviewList` (categories with `uploadAllowed: false` can never reach a composer chip); stale ErrorBanner test mock removed.

Tests: server 413 pass, frontend 36 pass.

Adversarial review: opus APPROVE, gpt-5.5 APPROVE (2 orphan-sweep minors → fixed).