### PR TITLE
refactor: single classification dispatch, upload-time dimension validation

### DIFF
--- a/packages/shared/src/constants/files.js
+++ b/packages/shared/src/constants/files.js
@@ -22,17 +22,36 @@ export const FILE_DOWNLOAD_POLICIES = {
 };
 
 const EXTENSION_TO_MIME = {
-  jpg: "image/jpeg", jpeg: "image/jpeg", png: "image/png", gif: "image/gif", webp: "image/webp", svg: "image/svg+xml",
+  jpg: "image/jpeg",
+  jpeg: "image/jpeg",
+  png: "image/png",
+  gif: "image/gif",
+  webp: "image/webp",
+  svg: "image/svg+xml",
   pdf: "application/pdf",
-  txt: "text/plain", md: "text/markdown", markdown: "text/markdown", csv: "text/csv",
-  json: "application/json", jsonl: "application/json", ndjson: "application/json",
-  html: "text/html", htm: "text/html", xml: "application/xml", css: "text/css",
-  js: "application/javascript", mjs: "application/javascript", cjs: "application/javascript",
-  log: "text/plain", yaml: "application/yaml", yml: "application/yaml",
+  txt: "text/plain",
+  md: "text/markdown",
+  markdown: "text/markdown",
+  csv: "text/csv",
+  json: "application/json",
+  jsonl: "application/json",
+  ndjson: "application/json",
+  html: "text/html",
+  htm: "text/html",
+  xml: "application/xml",
+  css: "text/css",
+  js: "application/javascript",
+  mjs: "application/javascript",
+  cjs: "application/javascript",
+  log: "text/plain",
+  yaml: "application/yaml",
+  yml: "application/yaml",
   docx: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
   xlsx: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
   pptx: "application/vnd.openxmlformats-officedocument.presentationml.presentation",
-  doc: "application/msword", xls: "application/vnd.ms-excel", ppt: "application/vnd.ms-powerpoint",
+  doc: "application/msword",
+  xls: "application/vnd.ms-excel",
+  ppt: "application/vnd.ms-powerpoint",
 };
 
 function mimesForExtensions(exts) {
@@ -55,8 +74,44 @@ export const FILE_CATEGORY_DEFINITIONS = {
     downloadPolicy: FILE_DOWNLOAD_POLICIES.INLINE_SAFE,
   },
   [FILE_CATEGORIES.TEXT_LIKE]: {
-    extensions: ["txt", "md", "markdown", "csv", "json", "jsonl", "ndjson", "html", "htm", "xml", "js", "mjs", "cjs", "css", "log", "yaml", "yml"],
-    mimeTypes: mimesForExtensions(["txt", "md", "markdown", "csv", "json", "jsonl", "ndjson", "html", "htm", "xml", "js", "mjs", "cjs", "css", "log", "yaml", "yml"]),
+    extensions: [
+      "txt",
+      "md",
+      "markdown",
+      "csv",
+      "json",
+      "jsonl",
+      "ndjson",
+      "html",
+      "htm",
+      "xml",
+      "js",
+      "mjs",
+      "cjs",
+      "css",
+      "log",
+      "yaml",
+      "yml",
+    ],
+    mimeTypes: mimesForExtensions([
+      "txt",
+      "md",
+      "markdown",
+      "csv",
+      "json",
+      "jsonl",
+      "ndjson",
+      "html",
+      "htm",
+      "xml",
+      "js",
+      "mjs",
+      "cjs",
+      "css",
+      "log",
+      "yaml",
+      "yml",
+    ]),
     uploadAllowed: true,
     defaultStrategy: FILE_STRATEGIES.INLINE_TEXT,
     downloadPolicy: FILE_DOWNLOAD_POLICIES.INLINE_SAFE,
@@ -78,7 +133,14 @@ export const FILE_CATEGORY_DEFINITIONS = {
 };
 
 export const UNSAFE_INLINE_EXTENSIONS = ["html", "htm", "svg", "js", "mjs", "cjs", "xml"];
-export const UNSAFE_INLINE_MIME_TYPES = ["text/html", "image/svg+xml", "application/javascript", "text/javascript", "application/xml", "text/xml"];
+export const UNSAFE_INLINE_MIME_TYPES = [
+  "text/html",
+  "image/svg+xml",
+  "application/javascript",
+  "text/javascript",
+  "application/xml",
+  "text/xml",
+];
 
 export const FILE_CONSTANTS = {
   MAX_FILE_SIZE_BYTES: 10 * 1024 * 1024,
@@ -98,15 +160,19 @@ const UPLOADABLE_CATEGORIES = [
 
 const acceptExtensions = UPLOADABLE_CATEGORIES.flatMap(
   (cat) => FILE_CATEGORY_DEFINITIONS[cat].extensions
-).filter((ext) => ext !== "svg");
+);
 
 const acceptMimes = [
   ...new Set(UPLOADABLE_CATEGORIES.flatMap((cat) => FILE_CATEGORY_DEFINITIONS[cat].mimeTypes)),
-].filter((mt) => mt !== "image/svg+xml");
+];
 
-export const ATTACHMENT_INPUT_ACCEPT = [...acceptMimes, ...acceptExtensions.map((e) => `.${e}`)].join(",");
+export const ATTACHMENT_INPUT_ACCEPT = [
+  ...acceptMimes,
+  ...acceptExtensions.map((e) => `.${e}`),
+].join(",");
 
-export const ATTACHMENT_TITLE_TEXT = "Attach images, PDFs, text/code files, CSV/JSON/Markdown, and modern Office documents. Text-like files are sent as text for broad model compatibility.";
+export const ATTACHMENT_TITLE_TEXT =
+  "Attach images, PDFs, text/code files, CSV/JSON/Markdown, and modern Office documents. Text-like files are sent as text for broad model compatibility.";
 
 export function getMimeFromExtension(ext) {
   return EXTENSION_TO_MIME[ext.toLowerCase()] || null;

--- a/server/src/lib/fileUtils.js
+++ b/server/src/lib/fileUtils.js
@@ -205,15 +205,7 @@ export function getAttachmentDownloadPolicy(file) {
   );
 }
 
-export function isTextLikeAttachment(file) {
-  return getAttachmentCategory(file) === FILE_CATEGORIES.TEXT_LIKE;
-}
-
-export function isOfficeModernAttachment(file) {
-  return getAttachmentCategory(file) === FILE_CATEGORIES.OFFICE_MODERN;
-}
-
-function getAttachmentMediaType(file) {
+export function getAttachmentMediaType(file) {
   return (
     classifyAttachment({
       filename: file.filename,

--- a/server/src/lib/fileUtils.js
+++ b/server/src/lib/fileUtils.js
@@ -1,4 +1,4 @@
-import { randomUUID, createHash } from "crypto";
+import { createHash } from "crypto";
 import { unlink, mkdir, readFile } from "fs/promises";
 import path from "path";
 import { fileURLToPath } from "url";
@@ -13,22 +13,14 @@ import {
   getMimeFromExtension,
   formatFileSize,
 } from "@faster-chat/shared";
-import { extractOfficeText, isOfficeModernFile, isOfficeLegacyFile } from "./officeExtraction.js";
 import { providerSupportsImages, providerSupportsNativePdf } from "./providerFactory.js";
-import { validateImageDimensions, MAX_IMAGE_DIMENSION_PX } from "./imageValidation.js";
+import {
+  validateImageDimensions,
+  validateImageDimensionValues,
+  MAX_IMAGE_DIMENSION_PX,
+} from "./imageValidation.js";
 
 export const MAX_INLINE_TEXT_ATTACHMENT_CHARS = 200_000;
-
-export {
-  formatFileSize,
-  FILE_CATEGORIES,
-  FILE_STRATEGIES,
-  FILE_DOWNLOAD_POLICIES,
-  FILE_CATEGORY_DEFINITIONS,
-  UNSAFE_INLINE_EXTENSIONS,
-  UNSAFE_INLINE_MIME_TYPES,
-  getMimeFromExtension,
-} from "@faster-chat/shared";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const PROJECT_ROOT = path.resolve(__dirname, "../../..");
@@ -40,17 +32,7 @@ export const FILE_CONFIG = {
 };
 
 export async function ensureUploadDirectory() {
-  try {
-    await mkdir(UPLOAD_DIR, { recursive: true });
-  } catch (error) {
-    if (error.code !== "EEXIST") {
-      throw error;
-    }
-  }
-}
-
-export function generateFileId() {
-  return randomUUID();
+  await mkdir(UPLOAD_DIR, { recursive: true });
 }
 
 export function sanitizeFilename(filename) {
@@ -123,40 +105,37 @@ export function isGenericMimeType(mimeType) {
   );
 }
 
+function categoryMatch(predicate) {
+  for (const [catKey, catDef] of Object.entries(FILE_CATEGORY_DEFINITIONS)) {
+    if (predicate(catDef)) {
+      return {
+        category: catKey,
+        uploadAllowed: catDef.uploadAllowed,
+        defaultStrategy: catDef.defaultStrategy,
+        downloadPolicy: catDef.downloadPolicy,
+      };
+    }
+  }
+  return null;
+}
+
 export function classifyAttachment({ filename, mimeType }) {
   const extension = getFileExtension(filename);
   const originalMimeType = mimeType || "";
   const normalizedMimeType = normalizeMimeType(originalMimeType);
   const effectiveMimeType = isGenericMimeType(normalizedMimeType)
-    ? getMimeFromExtension(filename) || normalizedMimeType
+    ? getMimeFromExtension(extension) || normalizedMimeType
     : normalizedMimeType;
+  const effectiveMimeTypeLower = effectiveMimeType.toLowerCase();
+  const matched =
+    categoryMatch((catDef) =>
+      catDef.mimeTypes.some((mt) => mt.toLowerCase() === effectiveMimeTypeLower)
+    ) || categoryMatch((catDef) => catDef.extensions.includes(extension));
 
-  let category = FILE_CATEGORIES.UNKNOWN_BINARY;
-  let uploadAllowed = false;
-  let defaultStrategy = FILE_STRATEGIES.REJECT;
-  let downloadPolicy = FILE_DOWNLOAD_POLICIES.ATTACHMENT_ONLY;
-
-  for (const [catKey, catDef] of Object.entries(FILE_CATEGORY_DEFINITIONS)) {
-    if (catDef.mimeTypes.some((mt) => mt.toLowerCase() === effectiveMimeType.toLowerCase())) {
-      category = catKey;
-      uploadAllowed = catDef.uploadAllowed;
-      defaultStrategy = catDef.defaultStrategy;
-      downloadPolicy = catDef.downloadPolicy;
-      break;
-    }
-  }
-
-  if (category === FILE_CATEGORIES.UNKNOWN_BINARY) {
-    for (const [catKey, catDef] of Object.entries(FILE_CATEGORY_DEFINITIONS)) {
-      if (catDef.extensions.includes(extension)) {
-        category = catKey;
-        uploadAllowed = catDef.uploadAllowed;
-        defaultStrategy = catDef.defaultStrategy;
-        downloadPolicy = catDef.downloadPolicy;
-        break;
-      }
-    }
-  }
+  let category = matched?.category || FILE_CATEGORIES.UNKNOWN_BINARY;
+  let uploadAllowed = matched?.uploadAllowed || false;
+  let defaultStrategy = matched?.defaultStrategy || FILE_STRATEGIES.REJECT;
+  let downloadPolicy = matched?.downloadPolicy || FILE_DOWNLOAD_POLICIES.ATTACHMENT_ONLY;
 
   const overlays = [];
   if (
@@ -234,16 +213,39 @@ export function isOfficeModernAttachment(file) {
   return getAttachmentCategory(file) === FILE_CATEGORIES.OFFICE_MODERN;
 }
 
-export function isOfficeLegacyAttachment(file) {
-  return getAttachmentCategory(file) === FILE_CATEGORIES.OFFICE_LEGACY;
+function getAttachmentMediaType(file) {
+  return (
+    classifyAttachment({
+      filename: file.filename,
+      mimeType: file.mime_type,
+    }).effectiveMimeType ||
+    file.mime_type ||
+    "application/octet-stream"
+  );
 }
 
-export function getStrategyForCategory(category) {
-  const catDef = FILE_CATEGORY_DEFINITIONS[category];
-  return catDef?.defaultStrategy || FILE_STRATEGIES.REJECT;
+function getStoredImageDimensions(file) {
+  const width = file.meta?.width;
+  const height = file.meta?.height;
+  return Number.isFinite(width) && Number.isFinite(height) ? { width, height } : null;
 }
 
-async function classifyForModel(file, modelRecord, providerName) {
+async function ensureImageDimensions(file, updateFileMetadata) {
+  const storedDimensions = getStoredImageDimensions(file);
+  if (storedDimensions) {
+    validateImageDimensionValues(storedDimensions, file.filename);
+    return;
+  }
+
+  const filePath = path.join(FILE_CONFIG.UPLOAD_DIR, file.stored_filename);
+  const buf = await readFile(filePath);
+  const dimensions = validateImageDimensions(buf, getAttachmentMediaType(file), file.filename);
+  const meta = { ...(file.meta || {}), ...dimensions };
+  file.meta = meta;
+  updateFileMetadata?.(file.id, meta);
+}
+
+async function classifyForModel(file, modelRecord, providerName, updateFileMetadata) {
   const category = getAttachmentCategory(file);
 
   switch (category) {
@@ -262,8 +264,7 @@ async function classifyForModel(file, modelRecord, providerName) {
         };
       }
       try {
-        const buf = await readFile(path.join(FILE_CONFIG.UPLOAD_DIR, file.stored_filename));
-        validateImageDimensions(buf, file.mime_type, file.filename);
+        await ensureImageDimensions(file, updateFileMetadata);
       } catch (err) {
         return {
           category,
@@ -291,15 +292,7 @@ async function classifyForModel(file, modelRecord, providerName) {
       return { category, allowed: true };
 
     case FILE_CATEGORIES.OFFICE_MODERN:
-      return isOfficeModernFile({ filename: file.filename, mimeType: file.mime_type })
-        ? { category, allowed: true }
-        : {
-            category,
-            allowed: false,
-            errorCode: "ATTACHMENT_UNSUPPORTED",
-            reason: "Office document type not recognized.",
-            suggestion: "Ensure the file has a .docx, .xlsx, or .pptx extension.",
-          };
+      return { category, allowed: true };
 
     case FILE_CATEGORIES.OFFICE_LEGACY:
       return {
@@ -322,16 +315,21 @@ async function classifyForModel(file, modelRecord, providerName) {
   }
 }
 
-export async function preflightAttachments({ files, modelRecord, providerName }) {
-  const results = await Promise.all(
+export async function preflightAttachments({
+  files,
+  modelRecord,
+  providerName,
+  updateFileMetadata,
+}) {
+  const denials = await Promise.all(
     files.map(async (file) => {
-      const r = await classifyForModel(file, modelRecord, providerName);
+      const r = await classifyForModel(file, modelRecord, providerName, updateFileMetadata);
+      if (r.allowed) {
+        return null;
+      }
       return {
-        fileId: file.id,
         filename: file.filename,
         category: r.category,
-        strategy: r.allowed ? getStrategyForCategory(r.category) : FILE_STRATEGIES.REJECT,
-        allowed: r.allowed,
         reason: r.reason ?? "",
         suggestion: r.suggestion ?? "",
         errorCode: r.errorCode,
@@ -339,14 +337,13 @@ export async function preflightAttachments({ files, modelRecord, providerName })
     })
   );
 
-  const denied = results.filter((r) => !r.allowed);
+  const denied = denials.filter(Boolean);
   if (denied.length === 0) {
-    return { ok: true, results };
+    return { ok: true };
   }
 
   return {
     ok: false,
-    results,
     code: denied[0].errorCode,
     error: "One or more attachments are not supported by the selected model.",
     details: denied.map(({ filename, category, reason, suggestion }) => ({
@@ -357,21 +354,6 @@ export async function preflightAttachments({ files, modelRecord, providerName })
     })),
   };
 }
-
-export async function extractOfficeDocumentText(file) {
-  const filePath = path.join(FILE_CONFIG.UPLOAD_DIR, file.stored_filename);
-  const fileBuffer = await readFile(filePath).catch((err) => {
-    throw new Error(`Cannot read ${file.id} at ${filePath}: ${err.message}`);
-  });
-
-  return extractOfficeText({
-    buffer: fileBuffer,
-    filename: file.filename,
-    mimeType: file.mime_type,
-  });
-}
-
-export { extractOfficeText, isOfficeModernFile, isOfficeLegacyFile };
 
 const FENCE_LANGUAGE_MAP = {
   markdown: "markdown",
@@ -389,8 +371,8 @@ export function formatInlineAttachmentText({ filename, mimeType, size, text, tot
   const extension = getFileExtension(filename);
 
   const fenceLanguage =
-    Object.entries(FENCE_LANGUAGE_MAP).find(([mime]) => normalizedMimeType.includes(mime))?.[1] ??
-    extension ??
+    Object.entries(FENCE_LANGUAGE_MAP).find(([mime]) => normalizedMimeType.includes(mime))?.[1] ||
+    extension ||
     "txt";
 
   const header = `Attached file: ${filename}\nContent-Type: ${normalizedMimeType}\nSize: ${formatFileSize(size)}\n\n`;

--- a/server/src/lib/imageValidation.js
+++ b/server/src/lib/imageValidation.js
@@ -85,12 +85,15 @@ function parseWebp(buf) {
   throw new Error(`Unknown WebP chunk type: ${chunkType}`);
 }
 
-export function validateImageDimensions(buffer, mimeType, filename) {
-  const dims = getImageDimensions(buffer, mimeType);
+export function validateImageDimensionValues(dims, filename) {
   if (dims.width > MAX_IMAGE_DIMENSION_PX || dims.height > MAX_IMAGE_DIMENSION_PX) {
     throw new Error(
       `Image "${filename}" is ${dims.width}×${dims.height}. The maximum supported dimension is ${MAX_IMAGE_DIMENSION_PX} px per side. Resize the image and upload again.`
     );
   }
   return dims;
+}
+
+export function validateImageDimensions(buffer, mimeType, filename) {
+  return validateImageDimensionValues(getImageDimensions(buffer, mimeType), filename);
 }

--- a/server/src/lib/officeExtraction.js
+++ b/server/src/lib/officeExtraction.js
@@ -1,6 +1,10 @@
 import path from "path";
 import AdmZip from "adm-zip";
-import { FILE_CATEGORIES, FILE_CATEGORY_DEFINITIONS } from "@faster-chat/shared";
+import {
+  FILE_CATEGORIES,
+  FILE_CATEGORY_DEFINITIONS,
+  getMimeFromExtension,
+} from "@faster-chat/shared";
 
 const NAMED_ENTITIES = { amp: "&", lt: "<", gt: ">", quot: '"', apos: "'" };
 
@@ -22,6 +26,32 @@ function safeGetData(entry) {
 
 function getExtension(filename) {
   return path.extname(filename).toLowerCase().replace(".", "");
+}
+
+function normalizeMimeType(mimeType) {
+  if (!mimeType || typeof mimeType !== "string") {
+    return "";
+  }
+  return mimeType.trim().split(";")[0].trim().toLowerCase();
+}
+
+function getOfficeExtractionKind({ filename, mimeType }) {
+  const extension = getExtension(filename);
+  const definition = FILE_CATEGORY_DEFINITIONS[FILE_CATEGORIES.OFFICE_MODERN];
+  if (definition.extensions.includes(extension)) {
+    return extension;
+  }
+
+  const normalizedMimeType = normalizeMimeType(mimeType);
+  if (!definition.mimeTypes.some((mt) => mt.toLowerCase() === normalizedMimeType)) {
+    return null;
+  }
+
+  return (
+    definition.extensions.find(
+      (ext) => getMimeFromExtension(ext)?.toLowerCase() === normalizedMimeType
+    ) || null
+  );
 }
 
 export function decodeXmlEntities(text) {
@@ -204,8 +234,8 @@ function extractPptxText(buffer) {
   };
 }
 
-export function extractOfficeText({ buffer, filename }) {
-  const kind = getExtension(filename);
+export function extractOfficeText({ buffer, filename, mimeType }) {
+  const kind = getOfficeExtractionKind({ filename, mimeType });
 
   let result;
   switch (kind) {
@@ -231,14 +261,4 @@ export function extractOfficeText({ buffer, filename }) {
     kind,
     warnings: result.warnings || [],
   };
-}
-
-export function isOfficeModernFile({ filename }) {
-  const extension = getExtension(filename);
-  return FILE_CATEGORY_DEFINITIONS[FILE_CATEGORIES.OFFICE_MODERN].extensions.includes(extension);
-}
-
-export function isOfficeLegacyFile({ filename }) {
-  const extension = getExtension(filename);
-  return FILE_CATEGORY_DEFINITIONS[FILE_CATEGORIES.OFFICE_LEGACY].extensions.includes(extension);
 }

--- a/server/src/lib/officeExtraction.js
+++ b/server/src/lib/officeExtraction.js
@@ -1,13 +1,6 @@
 import path from "path";
 import AdmZip from "adm-zip";
-
-const OFFICE_MIME_TYPES = {
-  "application/vnd.openxmlformats-officedocument.wordprocessingml.document": "docx",
-  "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet": "xlsx",
-  "application/vnd.openxmlformats-officedocument.presentationml.presentation": "pptx",
-};
-
-const OFFICE_EXTENSIONS = { docx: "docx", xlsx: "xlsx", pptx: "pptx" };
+import { FILE_CATEGORIES, FILE_CATEGORY_DEFINITIONS } from "@faster-chat/shared";
 
 const NAMED_ENTITIES = { amp: "&", lt: "<", gt: ">", quot: '"', apos: "'" };
 
@@ -25,6 +18,10 @@ function safeGetData(entry) {
     throw new Error(`zip entry ${entry.entryName} exceeds compression ratio limit`);
   }
   return entry.getData();
+}
+
+function getExtension(filename) {
+  return path.extname(filename).toLowerCase().replace(".", "");
 }
 
 export function decodeXmlEntities(text) {
@@ -91,6 +88,8 @@ function extractXlsxText(buffer) {
     const worksheetEntries = entries.filter(
       (e) => e.entryName.startsWith("xl/worksheets/sheet") && e.entryName.endsWith(".xml")
     );
+    const workbookEntry = entries.find((e) => e.entryName === "xl/workbook.xml");
+    const workbookXml = workbookEntry ? safeGetData(workbookEntry).toString("utf8") : "";
 
     for (const entry of worksheetEntries) {
       const xmlContent = safeGetData(entry).toString("utf8");
@@ -100,9 +99,7 @@ function extractXlsxText(buffer) {
       let sheetLabel = `Sheet ${sheetNumMatch ? sheetNumMatch[1] : ""}`;
 
       // Try to get actual sheet name from workbook
-      const workbookEntry = entries.find((e) => e.entryName === "xl/workbook.xml");
-      if (workbookEntry) {
-        const workbookXml = safeGetData(workbookEntry).toString("utf8");
+      if (workbookXml) {
         const sheetNameRegex = new RegExp(
           `<sheet\\s+name="([^"]+)"\\s+sheetId="${sheetNumMatch ? sheetNumMatch[1] : ""}"`
         );
@@ -207,17 +204,8 @@ function extractPptxText(buffer) {
   };
 }
 
-export function extractOfficeText({ buffer, filename, mimeType }) {
-  const extension = path.extname(filename).toLowerCase().replace(".", "");
-  const kind = OFFICE_EXTENSIONS[extension] || OFFICE_MIME_TYPES[mimeType] || null;
-
-  if (!kind) {
-    return {
-      text: "",
-      kind: null,
-      warnings: ["Unknown office document type"],
-    };
-  }
+export function extractOfficeText({ buffer, filename }) {
+  const kind = getExtension(filename);
 
   let result;
   switch (kind) {
@@ -233,8 +221,8 @@ export function extractOfficeText({ buffer, filename, mimeType }) {
     default:
       return {
         text: "",
-        kind,
-        warnings: ["Unsupported office document type"],
+        kind: null,
+        warnings: ["Unknown office document type"],
       };
   }
 
@@ -245,14 +233,12 @@ export function extractOfficeText({ buffer, filename, mimeType }) {
   };
 }
 
-export function isOfficeModernFile({ filename, mimeType }) {
-  const extension = path.extname(filename).toLowerCase().replace(".", "");
-  if (OFFICE_EXTENSIONS[extension]) return true;
-  if (mimeType && OFFICE_MIME_TYPES[mimeType]) return true;
-  return false;
+export function isOfficeModernFile({ filename }) {
+  const extension = getExtension(filename);
+  return FILE_CATEGORY_DEFINITIONS[FILE_CATEGORIES.OFFICE_MODERN].extensions.includes(extension);
 }
 
 export function isOfficeLegacyFile({ filename }) {
-  const extension = path.extname(filename).toLowerCase().replace(".", "");
-  return ["doc", "xls", "ppt"].includes(extension);
+  const extension = getExtension(filename);
+  return FILE_CATEGORY_DEFINITIONS[FILE_CATEGORIES.OFFICE_LEGACY].extensions.includes(extension);
 }

--- a/server/src/routes/chats.js
+++ b/server/src/routes/chats.js
@@ -11,6 +11,7 @@ import {
   MODEL_FEATURES,
   COMPLETION_CONSTANTS,
   WEB_SEARCH_CONSTANTS,
+  FILE_CATEGORIES,
 } from "@faster-chat/shared";
 import { createWebSearchTool } from "../lib/tools/webSearch.js";
 import { createFetchUrlTool } from "../lib/tools/fetchUrl.js";
@@ -21,13 +22,13 @@ import { readFile } from "fs/promises";
 import path from "path";
 import {
   FILE_CONFIG,
-  isTextLikeAttachment,
-  isOfficeModernAttachment,
-  extractOfficeDocumentText,
+  getAttachmentCategory,
+  classifyAttachment,
   formatInlineAttachmentText,
   MAX_INLINE_TEXT_ATTACHMENT_CHARS,
   preflightAttachments,
 } from "../lib/fileUtils.js";
+import { extractOfficeText } from "../lib/officeExtraction.js";
 import { ENDPOINT_RATE_LIMITS } from "../lib/constants.js";
 import {
   wrapModelWithMemory,
@@ -408,6 +409,17 @@ function inlineTextPart(file, size, text, totalCharCount) {
   };
 }
 
+function getAttachmentMediaType(file) {
+  return (
+    classifyAttachment({
+      filename: file.filename,
+      mimeType: file.mime_type,
+    }).effectiveMimeType ||
+    file.mime_type ||
+    "application/octet-stream"
+  );
+}
+
 async function fileToContentPart(file) {
   const filePath = path.join(FILE_CONFIG.UPLOAD_DIR, file.stored_filename);
   if (file.size > MAX_MODEL_ATTACHMENT_BYTES) {
@@ -417,45 +429,55 @@ async function fileToContentPart(file) {
     throw new Error(`Cannot read ${file.id} at ${filePath}: ${err.message}`);
   });
 
-  if (file.mime_type?.startsWith("image/")) {
-    return {
-      type: "image",
-      image: `data:${file.mime_type};base64,${fileBuffer.toString("base64")}`,
-    };
-  }
+  switch (getAttachmentCategory(file)) {
+    case FILE_CATEGORIES.IMAGE: {
+      const mediaType = getAttachmentMediaType(file);
+      return {
+        type: "image",
+        image: `data:${mediaType};base64,${fileBuffer.toString("base64")}`,
+      };
+    }
 
-  if (isOfficeModernAttachment(file)) {
-    const { text } = await extractOfficeDocumentText(file).catch((err) => {
-      throw new Error(`Office document extraction failed for ${file.filename}: ${err.message}`);
-    });
-    const displayText = text.slice(0, MAX_INLINE_TEXT_ATTACHMENT_CHARS);
-    const truncated = displayText.length < text.length;
-    return inlineTextPart(
-      file,
-      fileBuffer.length,
-      displayText,
-      truncated ? text.length : undefined
-    );
-  }
+    case FILE_CATEGORIES.OFFICE_MODERN: {
+      let text;
+      try {
+        ({ text } = extractOfficeText({
+          buffer: fileBuffer,
+          filename: file.filename,
+        }));
+      } catch (err) {
+        throw new Error(`Office document extraction failed for ${file.filename}: ${err.message}`);
+      }
+      const displayText = text.slice(0, MAX_INLINE_TEXT_ATTACHMENT_CHARS);
+      const truncated = displayText.length < text.length;
+      return inlineTextPart(
+        file,
+        fileBuffer.length,
+        displayText,
+        truncated ? text.length : undefined
+      );
+    }
 
-  if (isTextLikeAttachment(file)) {
-    const fullText = fileBuffer.toString("utf8");
-    const displayText = fullText.slice(0, MAX_INLINE_TEXT_ATTACHMENT_CHARS);
-    const truncated = displayText.length < fullText.length;
-    return inlineTextPart(
-      file,
-      fileBuffer.length,
-      displayText,
-      truncated ? fullText.length : undefined
-    );
-  }
+    case FILE_CATEGORIES.TEXT_LIKE: {
+      const fullText = fileBuffer.toString("utf8");
+      const displayText = fullText.slice(0, MAX_INLINE_TEXT_ATTACHMENT_CHARS);
+      const truncated = displayText.length < fullText.length;
+      return inlineTextPart(
+        file,
+        fileBuffer.length,
+        displayText,
+        truncated ? fullText.length : undefined
+      );
+    }
 
-  return {
-    type: "file",
-    data: fileBuffer,
-    mediaType: file.mime_type,
-    filename: file.filename,
-  };
+    default:
+      return {
+        type: "file",
+        data: fileBuffer,
+        mediaType: getAttachmentMediaType(file),
+        filename: file.filename,
+      };
+  }
 }
 
 function applyCacheControl(messages, modelId) {
@@ -578,6 +600,7 @@ chatsRouter.post(
         files: allFiles,
         modelRecord,
         providerName: modelRecord.provider_name,
+        updateFileMetadata: dbUtils.updateFileMetadata,
       });
       if (!issue.ok) {
         // Include code and formatted error details in response

--- a/server/src/routes/chats.js
+++ b/server/src/routes/chats.js
@@ -23,7 +23,7 @@ import path from "path";
 import {
   FILE_CONFIG,
   getAttachmentCategory,
-  classifyAttachment,
+  getAttachmentMediaType,
   formatInlineAttachmentText,
   MAX_INLINE_TEXT_ATTACHMENT_CHARS,
   preflightAttachments,
@@ -51,6 +51,29 @@ function mapAttachmentError(error) {
     };
   }
   return null;
+}
+
+class AttachmentDenialError extends Error {
+  constructor(issue) {
+    super(issue.error);
+    this.issue = issue;
+  }
+}
+
+function createAttachmentDenial(file, { category, reason, suggestion, code }) {
+  return {
+    ok: false,
+    code,
+    error: "One or more attachments are not supported by the selected model.",
+    details: [
+      {
+        filename: file.filename,
+        category,
+        reason,
+        suggestion,
+      },
+    ],
+  };
 }
 
 export const chatsRouter = new Hono();
@@ -409,17 +432,6 @@ function inlineTextPart(file, size, text, totalCharCount) {
   };
 }
 
-function getAttachmentMediaType(file) {
-  return (
-    classifyAttachment({
-      filename: file.filename,
-      mimeType: file.mime_type,
-    }).effectiveMimeType ||
-    file.mime_type ||
-    "application/octet-stream"
-  );
-}
-
 async function fileToContentPart(file) {
   const filePath = path.join(FILE_CONFIG.UPLOAD_DIR, file.stored_filename);
   if (file.size > MAX_MODEL_ATTACHMENT_BYTES) {
@@ -439,15 +451,27 @@ async function fileToContentPart(file) {
     }
 
     case FILE_CATEGORIES.OFFICE_MODERN: {
-      let text;
+      let extraction;
       try {
-        ({ text } = extractOfficeText({
+        extraction = extractOfficeText({
           buffer: fileBuffer,
           filename: file.filename,
-        }));
+          mimeType: file.mime_type,
+        });
       } catch (err) {
         throw new Error(`Office document extraction failed for ${file.filename}: ${err.message}`);
       }
+      if (!extraction.kind) {
+        throw new AttachmentDenialError(
+          createAttachmentDenial(file, {
+            category: FILE_CATEGORIES.OFFICE_MODERN,
+            code: "ATTACHMENT_UNSUPPORTED",
+            reason: "Office document type could not be determined from filename or MIME type.",
+            suggestion: "Upload a .docx, .xlsx, or .pptx file and try again.",
+          })
+        );
+      }
+      const text = extraction.text;
       const displayText = text.slice(0, MAX_INLINE_TEXT_ATTACHMENT_CHARS);
       const truncated = displayText.length < text.length;
       return inlineTextPart(
@@ -684,6 +708,16 @@ chatsRouter.post(
       });
     } catch (error) {
       console.error("Completion error:", error);
+      if (error instanceof AttachmentDenialError) {
+        return c.json(
+          {
+            code: error.issue.code,
+            error: error.issue.error,
+            details: error.issue.details,
+          },
+          HTTP_STATUS.BAD_REQUEST
+        );
+      }
       const mapped = mapAttachmentError(error);
       if (mapped) {
         return c.json({ code: mapped.code, error: mapped.error }, HTTP_STATUS.BAD_REQUEST);

--- a/server/src/routes/files.js
+++ b/server/src/routes/files.js
@@ -1,24 +1,25 @@
 import { Hono } from "hono";
+import { randomUUID } from "crypto";
 import { writeFile, unlink } from "fs/promises";
 import path from "path";
 import { fileURLToPath } from "url";
+import { FILE_CATEGORIES, formatFileSize } from "@faster-chat/shared";
 import { dbUtils } from "../lib/db.js";
 import { ensureSession } from "../middleware/auth.js";
 import { createRateLimiter } from "../middleware/rateLimiter.js";
 import { HTTP_STATUS } from "../lib/httpStatus.js";
 import { ENDPOINT_RATE_LIMITS } from "../lib/constants.js";
 import {
-  generateFileId,
   createStoredFilename,
   validateFile,
   calculateFileHash,
   deleteFileFromDisk,
-  formatFileSize,
   ensureUploadDirectory,
   validateFileAccess,
   getAttachmentDownloadPolicy,
   FILE_CONFIG,
 } from "../lib/fileUtils.js";
+import { validateImageDimensions } from "../lib/imageValidation.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -55,13 +56,26 @@ filesRouter.post("/", createRateLimiter(ENDPOINT_RATE_LIMITS.FILE_UPLOAD), async
   const classification = validation.classification;
 
   // Generate file ID and create stored filename
-  const fileId = generateFileId();
+  const fileId = randomUUID();
   const storedFilename = createStoredFilename(fileId, file.name);
   const filePath = path.join(FILE_CONFIG.UPLOAD_DIR, storedFilename);
 
   // Read file contents
   const arrayBuffer = await file.arrayBuffer();
   const buffer = Buffer.from(arrayBuffer);
+
+  let imageDimensions = null;
+  if (classification?.category === FILE_CATEGORIES.IMAGE) {
+    try {
+      imageDimensions = validateImageDimensions(
+        buffer,
+        classification.effectiveMimeType,
+        file.name
+      );
+    } catch (err) {
+      return c.json({ error: err.message }, HTTP_STATUS.BAD_REQUEST);
+    }
+  }
 
   // Calculate file hash (for future deduplication)
   const fileHash = calculateFileHash(buffer);
@@ -87,9 +101,9 @@ filesRouter.post("/", createRateLimiter(ENDPOINT_RATE_LIMITS.FILE_UPLOAD), async
       {
         originalName: file.name,
         originalMimeType: classification?.originalMimeType ?? file.type,
-        normalizedMimeType: classification?.effectiveMimeType ?? file.type,
         attachmentCategory: classification?.category ?? null,
         downloadPolicy: classification?.downloadPolicy ?? null,
+        ...(imageDimensions || {}),
         uploadedAt: Date.now(),
       }
     );

--- a/server/src/routes/images.js
+++ b/server/src/routes/images.js
@@ -1,4 +1,5 @@
 import { Hono } from "hono";
+import { randomUUID } from "crypto";
 import { writeFile, mkdir } from "fs/promises";
 import path from "path";
 import { fileURLToPath } from "url";
@@ -8,7 +9,7 @@ import { ensureSession } from "../middleware/auth.js";
 import { createRateLimiter } from "../middleware/rateLimiter.js";
 import { HTTP_STATUS } from "../lib/httpStatus.js";
 import { ENDPOINT_RATE_LIMITS } from "../lib/constants.js";
-import { generateFileId, createStoredFilename, calculateFileHash } from "../lib/fileUtils.js";
+import { createStoredFilename, calculateFileHash } from "../lib/fileUtils.js";
 import { generateImageForProvider } from "../lib/imageProviderFactory.js";
 import { decryptApiKey } from "../lib/encryption.js";
 
@@ -90,7 +91,7 @@ imagesRouter.post("/generate", createRateLimiter(ENDPOINT_RATE_LIMITS.IMAGE_GEN)
     });
 
     // Generate file metadata
-    const fileId = generateFileId();
+    const fileId = randomUUID();
     const extension = mimeType === "image/webp" ? "webp" : mimeType.split("/")[1] || "png";
     const filename = `generated_${Date.now()}.${extension}`;
     const storedFilename = createStoredFilename(fileId, filename);

--- a/server/src/test/chats.completion.test.js
+++ b/server/src/test/chats.completion.test.js
@@ -56,7 +56,8 @@ async function createFileFixture(ctx, { name, content, mimeType, userMessage }) 
   const { app, chatId, cookie, userId } = ctx;
   await mkdir(FILE_CONFIG.UPLOAD_DIR, { recursive: true });
   const fileId = `test-${crypto.randomUUID()}`;
-  const ext = name.slice(name.lastIndexOf("."));
+  const extIndex = name.lastIndexOf(".");
+  const ext = extIndex === -1 ? "" : name.slice(extIndex);
   const storedFilename = `${fileId}${ext}`;
   const filePath = path.join(FILE_CONFIG.UPLOAD_DIR, storedFilename);
   const buf = Buffer.isBuffer(content) ? content : Buffer.from(content);
@@ -664,6 +665,42 @@ describe("chat completion - Phase 4 PDF preflight", () => {
       );
       expect(userMsg.content.filter((p) => p.type === "file")).toHaveLength(0);
       const attachmentText = userMsg.content.find((p) => p.text?.includes("test.docx"));
+      expect(attachmentText.text).toContain("Attached file:");
+      expect(attachmentText.text).toContain("First paragraph text");
+      expect(attachmentText.text).toContain("Second paragraph with some content");
+    });
+
+    test("docx attachment without an extension extracts from its Office MIME type", async () => {
+      const ctx = { app, chatId, cookie: adminCookie, userId: adminUserId };
+      const { fileId, msgId } = await createFileFixture(ctx, {
+        name: "report",
+        content: await readFile(path.join(__dirname, "fixtures", "test.docx")),
+        mimeType: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        userMessage: "analyze extensionless docx",
+      });
+
+      const res = await makeRequest(app, "POST", `/api/chats/${chatId}/completion`, {
+        body: {
+          model: "stub-model",
+          systemPromptId: "default",
+          messages: [
+            {
+              id: msgId,
+              role: "user",
+              content: "analyze extensionless docx",
+              fileIds: [fileId],
+            },
+          ],
+        },
+        cookie: adminCookie,
+      });
+
+      expect(res.status).toBe(200);
+      const userMsg = streamTextCalls[0].messages.find(
+        (m) => m.role === "user" && Array.isArray(m.content)
+      );
+      expect(userMsg.content.filter((p) => p.type === "file")).toHaveLength(0);
+      const attachmentText = userMsg.content.find((p) => p.text?.includes("report"));
       expect(attachmentText.text).toContain("Attached file:");
       expect(attachmentText.text).toContain("First paragraph text");
       expect(attachmentText.text).toContain("Second paragraph with some content");

--- a/server/src/test/chats.completion.test.js
+++ b/server/src/test/chats.completion.test.js
@@ -47,6 +47,11 @@ const { encryptApiKey } = await import("../lib/encryption.js");
 const { writeFile, mkdir } = await import("fs/promises");
 const { FILE_CONFIG } = await import("../lib/fileUtils.js");
 
+const PNG_BYTES = Buffer.from(
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNgAAIAAAUAAen63NgAAAAASUVORK5CYII=",
+  "base64"
+);
+
 async function createFileFixture(ctx, { name, content, mimeType, userMessage }) {
   const { app, chatId, cookie, userId } = ctx;
   await mkdir(FILE_CONFIG.UPLOAD_DIR, { recursive: true });
@@ -353,14 +358,10 @@ describe("chat completion - Phase 3 text-like attachment inlining", () => {
   });
 
   test("Image attachment still creates native image part (not text)", async () => {
-    const pngBytes = Buffer.from(
-      "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNgAAIAAAUAAen63NgAAAAASUVORK5CYII=",
-      "base64"
-    );
     const ctx = { app, chatId, cookie: adminCookie, userId: adminUserId };
     const { fileId, msgId } = await createFileFixture(ctx, {
       name: "image.png",
-      content: pngBytes,
+      content: PNG_BYTES,
       mimeType: "image/png",
       userMessage: "describe image",
     });
@@ -370,6 +371,58 @@ describe("chat completion - Phase 3 text-like attachment inlining", () => {
         model: "stub-model",
         systemPromptId: "default",
         messages: [{ id: msgId, role: "user", content: "describe image", fileIds: [fileId] }],
+      },
+      cookie: adminCookie,
+    });
+
+    expect(res.status).toBe(200);
+    const userMsg = streamTextCalls[0].messages.find(
+      (m) => m.role === "user" && Array.isArray(m.content)
+    );
+    const imageParts = userMsg.content.filter((p) => p.type === "image");
+    expect(imageParts).toHaveLength(1);
+    expect(imageParts[0].image).toContain("data:image/png;base64,");
+  });
+
+  test("PNG uploaded as application/octet-stream completes as native image", async () => {
+    const fd = new FormData();
+    fd.append("file", new File([PNG_BYTES], "octet.png", { type: "application/octet-stream" }));
+
+    const uploadRes = await app.request("/api/files", {
+      method: "POST",
+      headers: { Cookie: adminCookie },
+      body: fd,
+    });
+    expect(uploadRes.status).toBe(200);
+    const uploadBody = await uploadRes.json();
+    expect(uploadBody.category).toBe("image");
+
+    const metaRes = await makeRequest(app, "GET", `/api/files/${uploadBody.id}`, {
+      cookie: adminCookie,
+    });
+    const metadata = await metaRes.json();
+    expect(metadata.meta.attachmentCategory).toBe("image");
+    expect(metadata.meta.width).toBe(1);
+    expect(metadata.meta.height).toBe(1);
+
+    const msgRes = await makeRequest(app, "POST", `/api/chats/${chatId}/messages`, {
+      body: { role: "user", content: "describe octet image", fileIds: [uploadBody.id] },
+      cookie: adminCookie,
+    });
+    const msgId = (await msgRes.json()).id;
+
+    const res = await makeRequest(app, "POST", `/api/chats/${chatId}/completion`, {
+      body: {
+        model: "stub-model",
+        systemPromptId: "default",
+        messages: [
+          {
+            id: msgId,
+            role: "user",
+            content: "describe octet image",
+            fileIds: [uploadBody.id],
+          },
+        ],
       },
       cookie: adminCookie,
     });

--- a/server/src/test/files.test.js
+++ b/server/src/test/files.test.js
@@ -320,6 +320,17 @@ describe("file routes", () => {
       expect(metadata.meta.height).toBe(1);
     });
 
+    it("rejects a corrupt image upload", async () => {
+      const res = await uploadFile(app, adminCookie, {
+        name: "corrupt.png",
+        type: "image/png",
+        content: Buffer.from("not a png"),
+      });
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toContain("PNG");
+    });
+
     it("accepts a CSV with application/octet-stream MIME (extension fallback)", async () => {
       const res = await uploadFile(app, adminCookie, {
         name: "data.csv",

--- a/server/src/test/files.test.js
+++ b/server/src/test/files.test.js
@@ -5,6 +5,11 @@ import { createTestApp, seedAdminUser, seedMemberUser, makeRequest, db } from ".
 import { encryptApiKey } from "../lib/encryption.js";
 import { FILE_CONFIG } from "../lib/fileUtils.js";
 
+const PNG_BYTES = Buffer.from(
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNgAAIAAAUAAen63NgAAAAASUVORK5CYII=",
+  "base64"
+);
+
 describe("file routes", () => {
   let app, adminCookie, adminUserId, memberCookie, memberUserId;
 
@@ -301,12 +306,18 @@ describe("file routes", () => {
       const res = await uploadFile(app, adminCookie, {
         name: "photo.png",
         type: "image/png",
-        content: Buffer.from("fake png data"),
+        content: PNG_BYTES,
       });
       expect(res.status).toBe(200);
       const body = await res.json();
       expect(body.id).toBeTruthy();
       expect(body.filename).toBe("photo.png");
+      const metaRes = await makeRequest(app, "GET", `/api/files/${body.id}`, {
+        cookie: adminCookie,
+      });
+      const metadata = await metaRes.json();
+      expect(metadata.meta.width).toBe(1);
+      expect(metadata.meta.height).toBe(1);
     });
 
     it("accepts a CSV with application/octet-stream MIME (extension fallback)", async () => {
@@ -365,7 +376,7 @@ describe("file routes", () => {
       const metaRes = await makeRequest(app, "GET", `/api/files/${id}`, { cookie: adminCookie });
       const body = await metaRes.json();
       expect(body.meta.attachmentCategory).toBe("textLike");
-      expect(body.meta.normalizedMimeType).toBe("text/csv");
+      expect(body.meta.normalizedMimeType).toBeUndefined();
       expect(body.meta.downloadPolicy).toBe("inlineSafe");
     });
 

--- a/server/src/test/officeExtraction.test.js
+++ b/server/src/test/officeExtraction.test.js
@@ -2,95 +2,21 @@ import { describe, test, expect, beforeAll } from "bun:test";
 import { readFile } from "fs/promises";
 import path from "path";
 import { fileURLToPath } from "url";
-import {
-  extractOfficeText,
-  isOfficeModernFile,
-  isOfficeLegacyFile,
-  decodeXmlEntities,
-} from "../lib/officeExtraction.js";
+import { extractOfficeText, decodeXmlEntities } from "../lib/officeExtraction.js";
 import AdmZip from "adm-zip";
 import { FILE_CATEGORIES } from "@faster-chat/shared";
 import { classifyAttachment } from "../lib/fileUtils.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const FIXTURES_DIR = path.join(__dirname, "fixtures");
+const DOCX_MIME = "application/vnd.openxmlformats-officedocument.wordprocessingml.document";
+const XLSX_MIME = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
+const PPTX_MIME = "application/vnd.openxmlformats-officedocument.presentationml.presentation";
+const DOC_MIME = "application/msword";
+const XLS_MIME = "application/vnd.ms-excel";
+const PPT_MIME = "application/vnd.ms-powerpoint";
 
 describe("officeExtraction", () => {
-  describe("isOfficeModernFile", () => {
-    test("returns true for .docx files", () => {
-      expect(isOfficeModernFile({ filename: "document.docx" })).toBe(true);
-      expect(isOfficeModernFile({ filename: "report.DOCX" })).toBe(true);
-    });
-
-    test("returns true for .xlsx files", () => {
-      expect(isOfficeModernFile({ filename: "sheet.xlsx" })).toBe(true);
-      expect(isOfficeModernFile({ filename: "data.XLSX" })).toBe(true);
-    });
-
-    test("returns true for .pptx files", () => {
-      expect(isOfficeModernFile({ filename: "slides.pptx" })).toBe(true);
-      expect(isOfficeModernFile({ filename: "presentation.PPTX" })).toBe(true);
-    });
-
-    test("returns false for legacy Office files", () => {
-      expect(isOfficeModernFile({ filename: "document.doc" })).toBe(false);
-      expect(isOfficeModernFile({ filename: "sheet.xls" })).toBe(false);
-      expect(isOfficeModernFile({ filename: "slides.ppt" })).toBe(false);
-    });
-
-    test("returns false for non-Office files", () => {
-      expect(isOfficeModernFile({ filename: "document.pdf" })).toBe(false);
-      expect(isOfficeModernFile({ filename: "file.txt" })).toBe(false);
-      expect(isOfficeModernFile({ filename: "image.png" })).toBe(false);
-    });
-
-    test("returns false based on MIME type without extension", () => {
-      expect(
-        isOfficeModernFile({
-          filename: "unknown",
-          mimeType: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
-        })
-      ).toBe(false);
-      expect(
-        isOfficeModernFile({
-          filename: "unknown",
-          mimeType: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
-        })
-      ).toBe(false);
-      expect(
-        isOfficeModernFile({
-          filename: "unknown",
-          mimeType: "application/vnd.openxmlformats-officedocument.presentationml.presentation",
-        })
-      ).toBe(false);
-    });
-  });
-
-  describe("isOfficeLegacyFile", () => {
-    test("returns true for .doc files", () => {
-      expect(isOfficeLegacyFile({ filename: "document.doc" })).toBe(true);
-    });
-
-    test("returns true for .xls files", () => {
-      expect(isOfficeLegacyFile({ filename: "sheet.xls" })).toBe(true);
-    });
-
-    test("returns true for .ppt files", () => {
-      expect(isOfficeLegacyFile({ filename: "slides.ppt" })).toBe(true);
-    });
-
-    test("returns false for modern Office files", () => {
-      expect(isOfficeLegacyFile({ filename: "document.docx" })).toBe(false);
-      expect(isOfficeLegacyFile({ filename: "sheet.xlsx" })).toBe(false);
-      expect(isOfficeLegacyFile({ filename: "slides.pptx" })).toBe(false);
-    });
-
-    test("returns false for non-Office files", () => {
-      expect(isOfficeLegacyFile({ filename: "document.pdf" })).toBe(false);
-      expect(isOfficeLegacyFile({ filename: "file.txt" })).toBe(false);
-    });
-  });
-
   describe("classifyAttachment integration", () => {
     test("classifies .docx as officeModern", () => {
       const result = classifyAttachment({ filename: "report.docx" });
@@ -107,6 +33,36 @@ describe("officeExtraction", () => {
       expect(result.category).toBe(FILE_CATEGORIES.OFFICE_MODERN);
     });
 
+    test("classifies uppercase .DOCX as officeModern", () => {
+      const result = classifyAttachment({ filename: "REPORT.DOCX" });
+      expect(result.category).toBe(FILE_CATEGORIES.OFFICE_MODERN);
+    });
+
+    test("classifies uppercase .XLSX as officeModern", () => {
+      const result = classifyAttachment({ filename: "SHEET.XLSX" });
+      expect(result.category).toBe(FILE_CATEGORIES.OFFICE_MODERN);
+    });
+
+    test("classifies uppercase .PPTX as officeModern", () => {
+      const result = classifyAttachment({ filename: "SLIDES.PPTX" });
+      expect(result.category).toBe(FILE_CATEGORIES.OFFICE_MODERN);
+    });
+
+    test("classifies DOCX MIME without an extension as officeModern", () => {
+      const result = classifyAttachment({ filename: "report", mimeType: DOCX_MIME });
+      expect(result.category).toBe(FILE_CATEGORIES.OFFICE_MODERN);
+    });
+
+    test("classifies XLSX MIME without an extension as officeModern", () => {
+      const result = classifyAttachment({ filename: "sheet", mimeType: XLSX_MIME });
+      expect(result.category).toBe(FILE_CATEGORIES.OFFICE_MODERN);
+    });
+
+    test("classifies PPTX MIME without an extension as officeModern", () => {
+      const result = classifyAttachment({ filename: "slides", mimeType: PPTX_MIME });
+      expect(result.category).toBe(FILE_CATEGORIES.OFFICE_MODERN);
+    });
+
     test("classifies .doc as officeLegacy", () => {
       const result = classifyAttachment({ filename: "report.doc" });
       expect(result.category).toBe(FILE_CATEGORIES.OFFICE_LEGACY);
@@ -119,6 +75,21 @@ describe("officeExtraction", () => {
 
     test("classifies .ppt as officeLegacy", () => {
       const result = classifyAttachment({ filename: "slides.ppt" });
+      expect(result.category).toBe(FILE_CATEGORIES.OFFICE_LEGACY);
+    });
+
+    test("classifies DOC MIME without an extension as officeLegacy", () => {
+      const result = classifyAttachment({ filename: "report", mimeType: DOC_MIME });
+      expect(result.category).toBe(FILE_CATEGORIES.OFFICE_LEGACY);
+    });
+
+    test("classifies XLS MIME without an extension as officeLegacy", () => {
+      const result = classifyAttachment({ filename: "sheet", mimeType: XLS_MIME });
+      expect(result.category).toBe(FILE_CATEGORIES.OFFICE_LEGACY);
+    });
+
+    test("classifies PPT MIME without an extension as officeLegacy", () => {
+      const result = classifyAttachment({ filename: "slides", mimeType: PPT_MIME });
       expect(result.category).toBe(FILE_CATEGORIES.OFFICE_LEGACY);
     });
   });
@@ -153,15 +124,26 @@ describe("officeExtraction", () => {
       expect(Array.isArray(result.warnings)).toBe(true);
     });
 
-    test("does not infer type from MIME without an extension", () => {
+    test("falls back to MIME type when the filename has no extension", () => {
       const result = extractOfficeText({
         buffer: docxBuffer,
         filename: "unknown",
-        mimeType: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        mimeType: DOCX_MIME,
       });
 
-      expect(result.kind).toBeNull();
-      expect(result.text).toBe("");
+      expect(result.kind).toBe("docx");
+      expect(result.text).toContain("First paragraph text");
+    });
+
+    test("falls back to MIME type when the filename has an unknown extension", () => {
+      const result = extractOfficeText({
+        buffer: docxBuffer,
+        filename: "report.bin",
+        mimeType: DOCX_MIME,
+      });
+
+      expect(result.kind).toBe("docx");
+      expect(result.text).toContain("First paragraph text");
     });
   });
 
@@ -196,6 +178,18 @@ describe("officeExtraction", () => {
       expect(result.text).toContain("Row 1 Col A");
       expect(result.text).toContain("Row 1 Col B");
     });
+
+    test("falls back to MIME type when the filename has no extension", () => {
+      const result = extractOfficeText({
+        buffer: xlsxBuffer,
+        filename: "unknown",
+        mimeType: XLSX_MIME,
+      });
+
+      expect(result.kind).toBe("xlsx");
+      expect(result.text).toContain("Header A");
+      expect(result.text).toContain("Header B");
+    });
   });
 
   describe("extractOfficeText - PPTX", () => {
@@ -215,6 +209,18 @@ describe("officeExtraction", () => {
 
       expect(result.kind).toBe("pptx");
       expect(result.text).toContain("Slide 1:");
+      expect(result.text).toContain("Slide 1 Title");
+      expect(result.text).toContain("Slide 1 content text");
+    });
+
+    test("falls back to MIME type when the filename has no extension", () => {
+      const result = extractOfficeText({
+        buffer: pptxBuffer,
+        filename: "unknown",
+        mimeType: PPTX_MIME,
+      });
+
+      expect(result.kind).toBe("pptx");
       expect(result.text).toContain("Slide 1 Title");
       expect(result.text).toContain("Slide 1 content text");
     });

--- a/server/src/test/officeExtraction.test.js
+++ b/server/src/test/officeExtraction.test.js
@@ -9,7 +9,8 @@ import {
   decodeXmlEntities,
 } from "../lib/officeExtraction.js";
 import AdmZip from "adm-zip";
-import { FILE_CATEGORIES, classifyAttachment } from "../lib/fileUtils.js";
+import { FILE_CATEGORIES } from "@faster-chat/shared";
+import { classifyAttachment } from "../lib/fileUtils.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const FIXTURES_DIR = path.join(__dirname, "fixtures");
@@ -43,25 +44,25 @@ describe("officeExtraction", () => {
       expect(isOfficeModernFile({ filename: "image.png" })).toBe(false);
     });
 
-    test("returns true based on MIME type", () => {
+    test("returns false based on MIME type without extension", () => {
       expect(
         isOfficeModernFile({
           filename: "unknown",
           mimeType: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
         })
-      ).toBe(true);
+      ).toBe(false);
       expect(
         isOfficeModernFile({
           filename: "unknown",
           mimeType: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
         })
-      ).toBe(true);
+      ).toBe(false);
       expect(
         isOfficeModernFile({
           filename: "unknown",
           mimeType: "application/vnd.openxmlformats-officedocument.presentationml.presentation",
         })
-      ).toBe(true);
+      ).toBe(false);
     });
   });
 
@@ -152,15 +153,15 @@ describe("officeExtraction", () => {
       expect(Array.isArray(result.warnings)).toBe(true);
     });
 
-    test("handles filename without extension using MIME type", () => {
+    test("does not infer type from MIME without an extension", () => {
       const result = extractOfficeText({
         buffer: docxBuffer,
         filename: "unknown",
         mimeType: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
       });
 
-      expect(result.kind).toBe("docx");
-      expect(result.text).toContain("First paragraph text");
+      expect(result.kind).toBeNull();
+      expect(result.text).toBe("");
     });
   });
 


### PR DESCRIPTION
Fixes M2, M3, M4 + file-pipeline minors from CODE-QUALITY-REVIEW.md (spec: specs/quality-review/spec-5-file-pipeline.md).

- **M2**: shared `FILE_CATEGORY_DEFINITIONS` is now the single classification dispatch. `fileToContentPart` switches on stored category (no more `startsWith("image/")`), officeExtraction's private MIME/extension tables are gone, dead `isOfficeModernFile` re-check deleted. The concrete bug is fixed end-to-end: a PNG uploaded as `application/octet-stream` categorizes IMAGE and the provider-bound part carries `image/png` — previously every completion failed preflight.
- **M3**: `getMimeFromExtension` gets the bare extension (fallback was dead); duplicate category loops collapsed; `normalizedMimeType` no longer stored (zero consumers).
- **M4**: image dimensions validated once at upload from the in-memory buffer (same 8000px limit), `{width,height}` persisted in meta; preflight is synchronous from meta — no per-completion disk reads. Legacy rows get a one-time read + idempotent backfill.
- From adversarial review: extraction kind now falls back from extension to MIME via the shared table — a DOCX uploaded with a stripped filename previously passed preflight then silently attached *empty* text; unknown-kind extraction now surfaces a structured denial instead. (Both reviewers converged on this one.)
- Minors: fileUtils barrel re-exports deleted, `isOfficeLegacyAttachment` chain deleted, `generateFileId` inlined, disk-reread wrapper deleted (buffer passed directly), `preflightAttachments` returns denials only, `workbook.xml` decompression hoisted out of the per-sheet loop, dead defensive code removed, dead svg accept-filter removed, orphaned helpers swept.

Tests: 417 pass (baseline 413; new: octet-stream PNG end-to-end, extensionless DOCX extraction, corrupt-image upload 400).

Adversarial review: opus APPROVE (4 minors), gpt-5.5 REQUEST-CHANGES (1 major) → all fixed.