### PR TITLE
refactor: db/routes structural cleanup

### DIFF
--- a/frontend/src/hooks/useChatStream.js
+++ b/frontend/src/hooks/useChatStream.js
@@ -63,15 +63,12 @@ export function useChatStream({
           const persistedIds = new Set(persistedForTransport.map((m) => m.id));
           const newMessages = (outgoingMessages ?? []).filter((m) => !persistedIds.has(m.id));
           const normalized = formatMessagesForTransport([...persistedForTransport, ...newMessages]);
-          const lastMessage = outgoingMessages?.[outgoingMessages.length - 1];
-          const fileIds = lastMessage?.fileIds || [];
 
           return {
             body: {
               model: modelRef.current,
               systemPromptId: "default",
               messages: normalized,
-              fileIds,
               webSearch: webSearchRef.current,
               memoryEnabled: memoryEnabledRef.current,
             },

--- a/server/src/app.js
+++ b/server/src/app.js
@@ -1,0 +1,76 @@
+import { Hono } from "hono";
+import { bodyLimit } from "hono/body-limit";
+import { cors } from "hono/cors";
+import { logger } from "hono/logger";
+import { installRouteErrorHandler } from "./lib/errorHandler.js";
+import { securityHeaders } from "./middleware/securityHeaders.js";
+import { adminRouter } from "./routes/admin.js";
+import { authRouter } from "./routes/auth.js";
+import { chatsRouter } from "./routes/chats.js";
+import { filesRouter } from "./routes/files.js";
+import { modelsRouter } from "./routes/models.js";
+import { providersRouter } from "./routes/providers.js";
+import { settingsRouter } from "./routes/settings.js";
+import { versionRouter } from "./routes/version.js";
+import { imagesRouter } from "./routes/images.js";
+import { importRouter } from "./routes/import.js";
+import { foldersRouter } from "./routes/folders.js";
+import { memoryRouter } from "./routes/memory.js";
+
+const REQUEST_BODY_LIMIT_BYTES = 50 * 1024 * 1024;
+
+export function createApp({ enableLogger = false } = {}) {
+  const app = new Hono();
+
+  installRouteErrorHandler(app);
+
+  app.use("*", securityHeaders());
+  if (enableLogger) {
+    app.use("*", logger());
+  }
+
+  app.use(
+    "/api/*",
+    bodyLimit({
+      maxSize: REQUEST_BODY_LIMIT_BYTES,
+      onError: (c) => c.json({ error: "Request body too large" }, 413),
+    })
+  );
+
+  app.use(
+    "/api/*",
+    cors({
+      origin: (origin) => {
+        if (process.env.NODE_ENV === "production") {
+          const allowedOrigin = process.env.APP_URL;
+          return origin === allowedOrigin ? origin : null;
+        }
+        if (!origin) {
+          return null;
+        }
+        try {
+          const url = new URL(origin);
+          return url.hostname === "localhost" || url.hostname === "127.0.0.1" ? origin : null;
+        } catch {
+          return null;
+        }
+      },
+      credentials: true,
+    })
+  );
+
+  app.route("/api/auth", authRouter);
+  app.route("/api/admin", adminRouter);
+  app.route("/api/admin/providers", providersRouter);
+  app.route("/api", modelsRouter);
+  app.route("/api/files", filesRouter);
+  app.route("/api/chats", chatsRouter);
+  app.route("/api/settings", settingsRouter);
+  app.route("/api/version", versionRouter);
+  app.route("/api/images", imagesRouter);
+  app.route("/api/import", importRouter);
+  app.route("/api/folders", foldersRouter);
+  app.route("/api/memory", memoryRouter);
+
+  return app;
+}

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -1,127 +1,15 @@
 import { serve } from "@hono/node-server";
 import { serveStatic } from "@hono/node-server/serve-static";
 import { config } from "dotenv";
-import { Hono } from "hono";
-import { bodyLimit } from "hono/body-limit";
-import { cors } from "hono/cors";
-import { logger } from "hono/logger";
 import { resolve } from "node:path";
 
 // Load environment variables
 config();
 
-// Import routes
+import { createApp } from "./app.js";
 import { initializeModelsDevCache } from "./lib/modelsdev.js";
-import { installRouteErrorHandler } from "./lib/errorHandler.js";
-import { securityHeaders } from "./middleware/securityHeaders.js";
-import { adminRouter } from "./routes/admin.js";
-import { authRouter } from "./routes/auth.js";
-import { chatsRouter } from "./routes/chats.js";
-import { filesRouter } from "./routes/files.js";
-import { modelsRouter } from "./routes/models.js";
-import { providersRouter } from "./routes/providers.js";
-import { settingsRouter } from "./routes/settings.js";
-import { versionRouter } from "./routes/version.js";
-import { imagesRouter } from "./routes/images.js";
-import { importRouter } from "./routes/import.js";
-import { foldersRouter } from "./routes/folders.js";
-import { memoryRouter } from "./routes/memory.js";
 
-const app = new Hono();
-
-installRouteErrorHandler(app);
-[
-  authRouter,
-  adminRouter,
-  providersRouter,
-  modelsRouter,
-  filesRouter,
-  chatsRouter,
-  settingsRouter,
-  versionRouter,
-  imagesRouter,
-  importRouter,
-  foldersRouter,
-  memoryRouter,
-].forEach(installRouteErrorHandler);
-
-// Security headers on all responses (before logger so they're always set)
-app.use("*", securityHeaders());
-app.use("*", logger());
-
-// Body size limit — reject oversized requests before hitting route handlers
-app.use("/api/*", async (c, next) => {
-  const contentLength = parseInt(c.req.header("content-length") || "0", 10);
-  if (contentLength > 50 * 1024 * 1024) {
-    return c.json({ error: "Request body too large" }, 413);
-  }
-  await next();
-});
-
-app.use(
-  "/api/*",
-  bodyLimit({
-    maxSize: 50 * 1024 * 1024,
-    onError: (c) => c.json({ error: "Request body too large" }, 413),
-  })
-);
-
-app.use(
-  "/api/*",
-  cors({
-    origin: (origin) => {
-      if (process.env.NODE_ENV === "production") {
-        const allowedOrigin = process.env.APP_URL;
-        return origin === allowedOrigin ? origin : null;
-      }
-      // Dev: allow localhost origins only — no wildcard fallback
-      if (!origin) {
-        return null;
-      }
-      try {
-        const url = new URL(origin);
-        return url.hostname === "localhost" || url.hostname === "127.0.0.1" ? origin : null;
-      } catch {
-        return null;
-      }
-    },
-    credentials: true,
-  })
-);
-
-// Public auth routes
-app.route("/api/auth", authRouter);
-
-// Protected admin routes
-app.route("/api/admin", adminRouter);
-app.route("/api/admin/providers", providersRouter);
-
-// Models routes (includes both public and admin)
-app.route("/api", modelsRouter);
-
-// Files routes (authentication handled in router)
-app.route("/api/files", filesRouter);
-
-// Chats routes (authentication handled in router)
-app.route("/api/chats", chatsRouter);
-
-// Settings routes (public GET, admin-only PUT)
-app.route("/api/settings", settingsRouter);
-
-// Version route (public, no auth)
-app.route("/api/version", versionRouter);
-
-// Images routes (image generation)
-app.route("/api/images", imagesRouter);
-
-// Import routes (conversation import from other platforms)
-app.route("/api/import", importRouter);
-
-// Folders routes (chat organization)
-app.route("/api/folders", foldersRouter);
-
-// Memory routes (user memory management)
-app.route("/api/memory", memoryRouter);
+const app = createApp({ enableLogger: true });
 
 // Serve static files in production
 if (process.env.NODE_ENV === "production") {

--- a/server/src/lib/completion.js
+++ b/server/src/lib/completion.js
@@ -1,0 +1,201 @@
+import { readFile } from "fs/promises";
+import path from "path";
+import { FILE_CATEGORIES, MODEL_FEATURES } from "@faster-chat/shared";
+import {
+  FILE_CONFIG,
+  getAttachmentCategory,
+  getAttachmentMediaType,
+  formatInlineAttachmentText,
+  MAX_INLINE_TEXT_ATTACHMENT_CHARS,
+} from "./fileUtils.js";
+import { extractOfficeText } from "./officeExtraction.js";
+
+const MAX_MODEL_ATTACHMENT_BYTES = 50 * 1024 * 1024;
+
+export function mapAttachmentError(error) {
+  const message = error.message || String(error);
+  if (message.includes("maximum supported dimension")) {
+    return { code: "ATTACHMENT_IMAGE_DIMENSIONS", error: message };
+  }
+  if (message.includes("media type") || message.includes("content type")) {
+    return {
+      code: "ATTACHMENT_UNSUPPORTED",
+      error: "One or more attachments are not supported by the selected model.",
+    };
+  }
+  return null;
+}
+
+export class AttachmentDenialError extends Error {
+  constructor(issue) {
+    super(issue.error);
+    this.issue = issue;
+  }
+}
+
+function createAttachmentDenial(file, { category, reason, suggestion, code }) {
+  return {
+    ok: false,
+    code,
+    error: "One or more attachments are not supported by the selected model.",
+    details: [
+      {
+        filename: file.filename,
+        category,
+        reason,
+        suggestion,
+      },
+    ],
+  };
+}
+
+function inlineTextPart(file, size, text, totalCharCount) {
+  return {
+    type: "text",
+    text: formatInlineAttachmentText({
+      filename: file.filename,
+      mimeType: file.mime_type,
+      size,
+      text,
+      totalCharCount,
+    }),
+  };
+}
+
+async function fileToContentPart(file) {
+  const filePath = path.join(FILE_CONFIG.UPLOAD_DIR, file.stored_filename);
+  if (file.size > MAX_MODEL_ATTACHMENT_BYTES) {
+    throw new Error(`Attachment ${file.filename} exceeds the per-file model limit`);
+  }
+  const fileBuffer = await readFile(filePath).catch((err) => {
+    throw new Error(`Cannot read ${file.id} at ${filePath}: ${err.message}`);
+  });
+
+  switch (getAttachmentCategory(file)) {
+    case FILE_CATEGORIES.IMAGE: {
+      const mediaType = getAttachmentMediaType(file);
+      return {
+        type: "image",
+        image: `data:${mediaType};base64,${fileBuffer.toString("base64")}`,
+      };
+    }
+
+    case FILE_CATEGORIES.OFFICE_MODERN: {
+      let extraction;
+      try {
+        extraction = extractOfficeText({
+          buffer: fileBuffer,
+          filename: file.filename,
+          mimeType: file.mime_type,
+        });
+      } catch (err) {
+        throw new Error(`Office document extraction failed for ${file.filename}: ${err.message}`);
+      }
+      if (!extraction.kind) {
+        throw new AttachmentDenialError(
+          createAttachmentDenial(file, {
+            category: FILE_CATEGORIES.OFFICE_MODERN,
+            code: "ATTACHMENT_UNSUPPORTED",
+            reason: "Office document type could not be determined from filename or MIME type.",
+            suggestion: "Upload a .docx, .xlsx, or .pptx file and try again.",
+          })
+        );
+      }
+      const text = extraction.text;
+      const displayText = text.slice(0, MAX_INLINE_TEXT_ATTACHMENT_CHARS);
+      const truncated = displayText.length < text.length;
+      return inlineTextPart(
+        file,
+        fileBuffer.length,
+        displayText,
+        truncated ? text.length : undefined
+      );
+    }
+
+    case FILE_CATEGORIES.TEXT_LIKE: {
+      const fullText = fileBuffer.toString("utf8");
+      const displayText = fullText.slice(0, MAX_INLINE_TEXT_ATTACHMENT_CHARS);
+      const truncated = displayText.length < fullText.length;
+      return inlineTextPart(
+        file,
+        fileBuffer.length,
+        displayText,
+        truncated ? fullText.length : undefined
+      );
+    }
+
+    default:
+      return {
+        type: "file",
+        data: fileBuffer,
+        mediaType: getAttachmentMediaType(file),
+        filename: file.filename,
+      };
+  }
+}
+
+export function applyCacheControl(messages, modelId) {
+  if (!MODEL_FEATURES.SUPPORTS_PROMPT_CACHING(modelId)) {
+    return messages;
+  }
+
+  return messages.map((msg, idx, arr) => {
+    if (msg.role === "system") {
+      return {
+        ...msg,
+        providerOptions: {
+          anthropic: { cacheControl: { type: MODEL_FEATURES.CACHE_TYPE } },
+        },
+      };
+    }
+
+    const isRecentMessage = idx >= arr.length - MODEL_FEATURES.CACHE_LAST_N_MESSAGES;
+    if (isRecentMessage && idx > 0) {
+      return {
+        ...msg,
+        providerOptions: {
+          anthropic: { cacheControl: { type: MODEL_FEATURES.CACHE_TYPE } },
+        },
+      };
+    }
+
+    return msg;
+  });
+}
+
+export async function createMultimodalContent(message, fileIds, filesById) {
+  const content = [];
+  let totalBytes = 0;
+  if (message.content.trim()) {
+    content.push({ type: "text", text: message.content });
+  }
+  for (const id of fileIds) {
+    const file = filesById.get(id);
+    totalBytes += file?.size || 0;
+    if (totalBytes > MAX_MODEL_ATTACHMENT_BYTES) {
+      throw new Error("Combined attachments exceed the model request limit");
+    }
+    content.push(await fileToContentPart(file));
+  }
+  return content;
+}
+
+export async function convertToModelMessages(messages, systemPrompt, filesById = new Map()) {
+  const result = systemPrompt ? [{ role: "system", content: systemPrompt }] : [];
+
+  for (const msg of messages) {
+    if (msg.role === "system") {
+      continue;
+    }
+
+    const msgFileIds = msg.fileIds || [];
+    if (msg.role === "user" && msgFileIds.length > 0) {
+      const content = await createMultimodalContent(msg, msgFileIds, filesById);
+      result.push({ role: msg.role, content });
+    } else {
+      result.push({ role: msg.role, content: msg.content });
+    }
+  }
+
+  return result;
+}

--- a/server/src/lib/db.js
+++ b/server/src/lib/db.js
@@ -1,5 +1,4 @@
 import { Database } from "bun:sqlite";
-import { randomBytes } from "crypto";
 import { config } from "dotenv";
 import { DB_CONSTANTS } from "@faster-chat/shared";
 import { encryptApiKey, decryptApiKey } from "./encryption.js";
@@ -55,28 +54,6 @@ function runMigrations(database) {
   }
 }
 
-function parseFileMeta(file) {
-  if (file?.meta) {
-    try {
-      file.meta = JSON.parse(file.meta);
-    } catch {
-      file.meta = null;
-    }
-  }
-  return file;
-}
-
-function parseMessageMetadata(message) {
-  if (message?.metadata) {
-    try {
-      message.metadata = JSON.parse(message.metadata);
-    } catch {
-      message.metadata = null;
-    }
-  }
-  return message;
-}
-
 function buildUpdateFields(updates, fieldMap, transforms = {}) {
   const fields = [];
   const values = [];
@@ -96,11 +73,11 @@ runMigrations(db);
 export const dbUtils = {};
 Object.assign(
   dbUtils,
-  createUserUtils({ db, DB_CONSTANTS, randomBytes }),
+  createUserUtils({ db }),
   createProviderUtils({ db, buildUpdateFields }),
   createModelUtils({ db, buildUpdateFields }),
-  createFileUtils({ db, parseFileMeta }),
-  createChatUtils({ db, parseMessageMetadata }),
+  createFileUtils({ db }),
+  createChatUtils({ db }),
   createFolderUtils({ db, buildUpdateFields }),
   createSettingUtils({ db, encryptApiKey, decryptApiKey }),
   createAuditUtils({ db }),

--- a/server/src/lib/db/chats.js
+++ b/server/src/lib/db/chats.js
@@ -1,4 +1,15 @@
-export function createChatUtils({ db, parseMessageMetadata }) {
+function parseMessageMetadata(message) {
+  if (message?.metadata) {
+    try {
+      message.metadata = JSON.parse(message.metadata);
+    } catch {
+      message.metadata = null;
+    }
+  }
+  return message;
+}
+
+export function createChatUtils({ db }) {
   // Batch fetch file IDs for messages, ordered by created_at ASC, rowid ASC
   function getMessageFileIds(messageIds) {
     if (!messageIds || messageIds.length === 0) {
@@ -65,18 +76,6 @@ export function createChatUtils({ db, parseMessageMetadata }) {
       return stmt.get(chatId, userId);
     },
 
-    getChatsByUserId(userId, includeArchived = false) {
-      const stmt = db.prepare(`
-      SELECT * FROM chats
-      WHERE user_id = ? AND deleted_at IS NULL AND folder_id IS NULL ${includeArchived ? "" : "AND archived_at IS NULL"}
-      ORDER BY
-        CASE WHEN pinned_at IS NOT NULL THEN 0 ELSE 1 END,
-        pinned_at DESC,
-        updated_at DESC
-    `);
-      return stmt.all(userId);
-    },
-
     getArchivedChatsByUserId(userId) {
       const stmt = db.prepare(`
       SELECT * FROM chats
@@ -110,13 +109,6 @@ export function createChatUtils({ db, parseMessageMetadata }) {
     updateChatTimestampTo(chatId, timestamp) {
       const stmt = db.prepare("UPDATE chats SET updated_at = ? WHERE id = ?");
       stmt.run(timestamp, chatId);
-    },
-
-    softDeleteChat(chatId) {
-      const now = Date.now();
-      const stmt = db.prepare("UPDATE chats SET deleted_at = ?, updated_at = ? WHERE id = ?");
-      const result = stmt.run(now, now, chatId);
-      return result.changes > 0;
     },
 
     softDeleteChatByUser(chatId, userId) {
@@ -161,12 +153,6 @@ export function createChatUtils({ db, parseMessageMetadata }) {
         "UPDATE chats SET archived_at = NULL, updated_at = ? WHERE id = ? AND user_id = ? AND deleted_at IS NULL"
       );
       const result = stmt.run(now, chatId, userId);
-      return result.changes > 0;
-    },
-
-    hardDeleteChat(chatId) {
-      const stmt = db.prepare("DELETE FROM chats WHERE id = ?");
-      const result = stmt.run(chatId);
       return result.changes > 0;
     },
 
@@ -219,34 +205,6 @@ export function createChatUtils({ db, parseMessageMetadata }) {
         metadata,
         created_at: now,
       };
-    },
-
-    getMessageById(messageId) {
-      const stmt = db.prepare("SELECT * FROM messages WHERE id = ?");
-      const msg = stmt.get(messageId);
-      if (!msg) return null;
-      parseMessageMetadata(msg);
-      attachFileIds([msg]);
-      return msg;
-    },
-
-    getMessagesByChatAndUser(chatId, userId) {
-      const stmt = db.prepare(`
-      SELECT * FROM messages
-      WHERE chat_id = ? AND user_id = ?
-      ORDER BY created_at ASC
-    `);
-      const messages = stmt.all(chatId, userId);
-      for (const msg of messages) {
-        parseMessageMetadata(msg);
-      }
-      return attachFileIds(messages);
-    },
-
-    deleteMessage(messageId) {
-      const stmt = db.prepare("DELETE FROM messages WHERE id = ?");
-      const result = stmt.run(messageId);
-      return result.changes > 0;
     },
 
     deleteMessageByUser(messageId, userId, chatId) {

--- a/server/src/lib/db/files.js
+++ b/server/src/lib/db/files.js
@@ -1,4 +1,15 @@
-export function createFileUtils({ db, parseFileMeta }) {
+function parseFileMeta(file) {
+  if (file?.meta) {
+    try {
+      file.meta = JSON.parse(file.meta);
+    } catch {
+      file.meta = null;
+    }
+  }
+  return file;
+}
+
+export function createFileUtils({ db }) {
   return {
     createFile(
       id,
@@ -44,15 +55,6 @@ export function createFileUtils({ db, parseFileMeta }) {
     getFilesByUserId(userId) {
       const stmt = db.prepare("SELECT * FROM files WHERE user_id = ? ORDER BY created_at DESC");
       return stmt.all(userId).map(parseFileMeta);
-    },
-
-    getFilesByIds(fileIds) {
-      if (!fileIds || fileIds.length === 0) {
-        return [];
-      }
-      const placeholders = fileIds.map(() => "?").join(",");
-      const stmt = db.prepare(`SELECT * FROM files WHERE id IN (${placeholders})`);
-      return stmt.all(...fileIds).map(parseFileMeta);
     },
 
     getFilesByIdsForUser(fileIds, userId) {

--- a/server/src/lib/db/memory.js
+++ b/server/src/lib/db/memory.js
@@ -69,26 +69,6 @@ export function createMemoryUtils({ db }) {
       db.prepare("UPDATE chats SET memory_disabled = ? WHERE id = ?").run(disabled ? 1 : 0, chatId);
     },
 
-    getMemoryGlobalEnabled() {
-      return this.getSetting("memory_enabled");
-    },
-
-    setMemoryGlobalEnabled(enabled) {
-      this.setSetting("memory_enabled", enabled ? "true" : "false");
-    },
-
-    getMemoryExtractionModel() {
-      return this.getSetting("memory_extraction_model");
-    },
-
-    setMemoryExtractionModel(modelId) {
-      if (modelId) {
-        this.setSetting("memory_extraction_model", modelId);
-      } else {
-        this.deleteSetting("memory_extraction_model");
-      }
-    },
-
     getMemoriesCount(userId) {
       const stmt = db.prepare("SELECT COUNT(*) as count FROM user_memories WHERE user_id = ?");
       const result = stmt.get(userId);

--- a/server/src/lib/db/users.js
+++ b/server/src/lib/db/users.js
@@ -1,4 +1,7 @@
-export function createUserUtils({ db, DB_CONSTANTS, randomBytes }) {
+import { randomBytes } from "crypto";
+import { DB_CONSTANTS } from "@faster-chat/shared";
+
+export function createUserUtils({ db }) {
   return {
     getUserByUsername(username) {
       const stmt = db.prepare("SELECT * FROM users WHERE username = ?");

--- a/server/src/lib/memory.js
+++ b/server/src/lib/memory.js
@@ -23,7 +23,7 @@ export function isMemoryEnabledForRequest({
   if (!requestEnabled || !userId) {
     return false;
   }
-  if (dbUtils.getMemoryGlobalEnabled() !== "true") {
+  if (dbUtils.getSetting("memory_enabled") !== "true") {
     return false;
   }
   if (!dbUtils.getUserMemoryEnabled(userId)) {
@@ -106,7 +106,7 @@ export async function extractMemories({
 
 export function getExtractionModel(dbUtils, decryptApiKey) {
   try {
-    const modelId = dbUtils.getMemoryExtractionModel();
+    const modelId = dbUtils.getSetting("memory_extraction_model");
     if (!modelId) {
       return null;
     }

--- a/server/src/lib/modelsdev.js
+++ b/server/src/lib/modelsdev.js
@@ -385,8 +385,6 @@ export function getReplicateImageModels() {
 
 let initPromise = null;
 let retryCount = 0;
-let retryHandle = null;
-let refreshHandle = null;
 const MAX_INIT_RETRIES = 5;
 const INITIAL_RETRY_DELAY_MS = 30000;
 
@@ -402,7 +400,7 @@ export function initializeModelsDevCache() {
     }
     const delay = INITIAL_RETRY_DELAY_MS * 2 ** retryCount;
     retryCount++;
-    retryHandle = setTimeout(() => {
+    const retryHandle = setTimeout(() => {
       initPromise = null;
       initializeModelsDevCache();
     }, delay);
@@ -413,20 +411,9 @@ export function initializeModelsDevCache() {
   return initPromise;
 }
 
-refreshHandle = setInterval(() => {
+const refreshHandle = setInterval(() => {
   fetchModelsDevDatabase().catch((error) => {
     console.error("Failed to refresh models.dev cache:", error.message);
   });
 }, CACHE_DURATION);
 refreshHandle.unref?.();
-
-export function stopModelsDevTimers() {
-  if (retryHandle) {
-    clearTimeout(retryHandle);
-    retryHandle = null;
-  }
-  if (refreshHandle) {
-    clearInterval(refreshHandle);
-    refreshHandle = null;
-  }
-}

--- a/server/src/lib/search/fetchUrl.js
+++ b/server/src/lib/search/fetchUrl.js
@@ -4,7 +4,7 @@ import { WEB_SEARCH_CONSTANTS, SEARCH_ERROR_CODES } from "@faster-chat/shared";
 import { validatePublicFetchUrl } from "../ssrf.js";
 
 const { MAX_CONTENT_LENGTH, FETCH_TIMEOUT_MS } = WEB_SEARCH_CONSTANTS;
-const { SSRF_BLOCKED, FETCH_FAILED } = SEARCH_ERROR_CODES;
+const { FETCH_FAILED } = SEARCH_ERROR_CODES;
 
 const MAX_REDIRECTS = 5;
 const USER_AGENT = "FasterChat/1.0";
@@ -77,7 +77,7 @@ function pinnedFetch(validated) {
 // --- Main export ---
 
 export async function fetchAndExtract(url) {
-  let validated = await validatePublicFetchUrl(url, { SSRF_BLOCKED, FETCH_FAILED });
+  let validated = await validatePublicFetchUrl(url);
   if (!validated.valid) {
     return validated;
   }
@@ -93,7 +93,7 @@ export async function fetchAndExtract(url) {
         }
 
         const next = new URL(location, validated.url).href;
-        validated = await validatePublicFetchUrl(next, { SSRF_BLOCKED, FETCH_FAILED });
+        validated = await validatePublicFetchUrl(next);
         if (!validated.valid) {
           return validated;
         }

--- a/server/src/lib/ssrf.js
+++ b/server/src/lib/ssrf.js
@@ -1,5 +1,8 @@
 import dns from "node:dns/promises";
 import net from "node:net";
+import { SEARCH_ERROR_CODES } from "@faster-chat/shared";
+
+const { SSRF_BLOCKED, FETCH_FAILED } = SEARCH_ERROR_CODES;
 
 const METADATA_HOSTNAMES = new Set([
   "169.254.169.254",
@@ -13,6 +16,26 @@ function stripIPv6Brackets(hostname) {
 
 function isMetadataAddress(ip) {
   return ip === "169.254.169.254" || ip === "100.100.100.200";
+}
+
+function parsePublicHttpUrl(url) {
+  let parsed;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return { error: "Invalid URL" };
+  }
+
+  if (!["http:", "https:"].includes(parsed.protocol)) {
+    return { error: "URL blocked for security reasons" };
+  }
+
+  const hostname = stripIPv6Brackets(parsed.hostname).toLowerCase();
+  if (!hostname || METADATA_HOSTNAMES.has(hostname)) {
+    return { error: "URL blocked for security reasons" };
+  }
+
+  return { parsed, hostname };
 }
 
 function isPrivateIPv4(ip) {
@@ -65,41 +88,18 @@ export function isPrivateAddress(ip) {
 }
 
 export function validateProviderBaseUrl(url) {
-  let parsed;
-  try {
-    parsed = new URL(url);
-  } catch {
-    return false;
-  }
-
-  if (!["http:", "https:"].includes(parsed.protocol)) {
-    return false;
-  }
-
-  const hostname = stripIPv6Brackets(parsed.hostname).toLowerCase();
-  return !!hostname && !METADATA_HOSTNAMES.has(hostname);
+  return !!parsePublicHttpUrl(url).parsed;
 }
 
-export async function validatePublicFetchUrl(url, errorCodes) {
-  let parsed;
-  try {
-    parsed = new URL(url);
-  } catch {
-    return { error: "Invalid URL", code: errorCodes.SSRF_BLOCKED };
-  }
-
-  if (!["http:", "https:"].includes(parsed.protocol)) {
-    return { error: "URL blocked for security reasons", code: errorCodes.SSRF_BLOCKED };
-  }
-
-  const hostname = stripIPv6Brackets(parsed.hostname).toLowerCase();
-  if (!hostname || METADATA_HOSTNAMES.has(hostname)) {
-    return { error: "URL blocked for security reasons", code: errorCodes.SSRF_BLOCKED };
+export async function validatePublicFetchUrl(url) {
+  const { parsed, hostname, error } = parsePublicHttpUrl(url);
+  if (!parsed) {
+    return { error, code: SSRF_BLOCKED };
   }
 
   if (net.isIP(hostname)) {
     if (isMetadataAddress(hostname) || isPrivateAddress(hostname)) {
-      return { error: "URL blocked for security reasons", code: errorCodes.SSRF_BLOCKED };
+      return { error: "URL blocked for security reasons", code: SSRF_BLOCKED };
     }
     return { valid: true, url: parsed.href, address: hostname };
   }
@@ -108,18 +108,18 @@ export async function validatePublicFetchUrl(url, errorCodes) {
   try {
     addresses = await dns.lookup(hostname, { all: true });
   } catch {
-    return { error: "DNS resolution failed", code: errorCodes.FETCH_FAILED };
+    return { error: "DNS resolution failed", code: FETCH_FAILED };
   }
 
   if (!addresses.length) {
-    return { error: "Could not resolve hostname", code: errorCodes.FETCH_FAILED };
+    return { error: "Could not resolve hostname", code: FETCH_FAILED };
   }
 
   const blocked = addresses.find(
     ({ address }) => isMetadataAddress(address) || isPrivateAddress(address)
   );
   if (blocked) {
-    return { error: "URL blocked for security reasons", code: errorCodes.SSRF_BLOCKED };
+    return { error: "URL blocked for security reasons", code: SSRF_BLOCKED };
   }
 
   // Return the validated address so the caller can pin the connection to it,

--- a/server/src/middleware/rateLimiter.js
+++ b/server/src/middleware/rateLimiter.js
@@ -24,11 +24,6 @@ export function createRateLimiter({ windowMs, maxRequests, keyFn }) {
   cleanupHandle.unref?.();
 
   const middleware = async (c, next) => {
-    if (process.env.DISABLE_RATE_LIMIT === "true") {
-      await next();
-      return;
-    }
-
     const key = resolveKey(c);
     const now = Date.now();
     const timestamps = store.get(key) || [];
@@ -42,6 +37,5 @@ export function createRateLimiter({ windowMs, maxRequests, keyFn }) {
     store.set(key, recent);
     await next();
   };
-  middleware.stop = () => clearInterval(cleanupHandle);
   return middleware;
 }

--- a/server/src/routes/auth.js
+++ b/server/src/routes/auth.js
@@ -26,9 +26,6 @@ export function _resetRateLimits() {
 }
 
 function checkRateLimit(bucketKey) {
-  if (process.env.DISABLE_RATE_LIMIT === "true") {
-    return true;
-  }
   return dbUtils.checkRateLimit(bucketKey, RATE_LIMIT.WINDOW_MS, RATE_LIMIT.MAX_ATTEMPTS);
 }
 

--- a/server/src/routes/chats.js
+++ b/server/src/routes/chats.js
@@ -8,27 +8,15 @@ import { HTTP_STATUS } from "../lib/httpStatus.js";
 import {
   UI_CONSTANTS,
   getSystemPrompt,
-  MODEL_FEATURES,
   COMPLETION_CONSTANTS,
   WEB_SEARCH_CONSTANTS,
-  FILE_CATEGORIES,
 } from "@faster-chat/shared";
 import { createWebSearchTool } from "../lib/tools/webSearch.js";
 import { createFetchUrlTool } from "../lib/tools/fetchUrl.js";
 import { decryptApiKey } from "../lib/encryption.js";
 import { getModelInstance } from "../lib/providerFactory.js";
 import { humanizeProviderError } from "../lib/providerErrors.js";
-import { readFile } from "fs/promises";
-import path from "path";
-import {
-  FILE_CONFIG,
-  getAttachmentCategory,
-  getAttachmentMediaType,
-  formatInlineAttachmentText,
-  MAX_INLINE_TEXT_ATTACHMENT_CHARS,
-  preflightAttachments,
-} from "../lib/fileUtils.js";
-import { extractOfficeText } from "../lib/officeExtraction.js";
+import { preflightAttachments } from "../lib/fileUtils.js";
 import { ENDPOINT_RATE_LIMITS } from "../lib/constants.js";
 import {
   wrapModelWithMemory,
@@ -36,45 +24,12 @@ import {
   getExtractionModel,
   isMemoryEnabledForRequest,
 } from "../lib/memory.js";
-
-const MAX_MODEL_ATTACHMENT_BYTES = 50 * 1024 * 1024;
-
-function mapAttachmentError(error) {
-  const message = error.message || String(error);
-  if (message.includes("maximum supported dimension")) {
-    return { code: "ATTACHMENT_IMAGE_DIMENSIONS", error: message };
-  }
-  if (message.includes("media type") || message.includes("content type")) {
-    return {
-      code: "ATTACHMENT_UNSUPPORTED",
-      error: "One or more attachments are not supported by the selected model.",
-    };
-  }
-  return null;
-}
-
-class AttachmentDenialError extends Error {
-  constructor(issue) {
-    super(issue.error);
-    this.issue = issue;
-  }
-}
-
-function createAttachmentDenial(file, { category, reason, suggestion, code }) {
-  return {
-    ok: false,
-    code,
-    error: "One or more attachments are not supported by the selected model.",
-    details: [
-      {
-        filename: file.filename,
-        category,
-        reason,
-        suggestion,
-      },
-    ],
-  };
-}
+import {
+  applyCacheControl,
+  AttachmentDenialError,
+  convertToModelMessages,
+  mapAttachmentError,
+} from "../lib/completion.js";
 
 export const chatsRouter = new Hono();
 
@@ -106,7 +61,7 @@ function chatStateHandler(action, message) {
     const user = c.get("user");
     const chatId = c.req.param("chatId");
 
-    const updated = action().call(dbUtils, chatId, user.id);
+    const updated = action(chatId, user.id);
     if (!updated) {
       return c.json({ error: "Chat not found" }, HTTP_STATUS.NOT_FOUND);
     }
@@ -165,14 +120,26 @@ chatsRouter.post("/", async (c) => {
   );
 });
 
-chatsRouter.get("/:chatId", async (c) => {
+async function loadChat(c, next) {
+  if (c.get("chat")) {
+    await next();
+    return;
+  }
   const user = c.get("user");
   const chatId = c.req.param("chatId");
-
   const chat = dbUtils.getChatByIdAndUser(chatId, user.id);
   if (!chat) {
     return c.json({ error: "Chat not found" }, HTTP_STATUS.NOT_FOUND);
   }
+  c.set("chat", chat);
+  await next();
+}
+
+chatsRouter.use("/:chatId", loadChat);
+chatsRouter.use("/:chatId/*", loadChat);
+
+chatsRouter.get("/:chatId", async (c) => {
+  const chat = c.get("chat");
 
   return c.json({
     id: chat.id,
@@ -184,15 +151,9 @@ chatsRouter.get("/:chatId", async (c) => {
 });
 
 chatsRouter.patch("/:chatId", async (c) => {
-  const user = c.get("user");
   const chatId = c.req.param("chatId");
   const body = await c.req.json();
   const validated = PatchChatSchema.parse(body);
-
-  const chat = dbUtils.getChatByIdAndUser(chatId, user.id);
-  if (!chat) {
-    return c.json({ error: "Chat not found" }, HTTP_STATUS.NOT_FOUND);
-  }
 
   if (validated.title !== undefined) {
     dbUtils.updateChatTitle(chatId, validated.title);
@@ -219,31 +180,23 @@ chatsRouter.delete("/:chatId", async (c) => {
   return c.json({ message: "Chat deleted successfully" });
 });
 
-chatsRouter.post(
-  "/:chatId/pin",
-  chatStateHandler(() => dbUtils.pinChat, "Chat pinned successfully")
-);
+chatsRouter.post("/:chatId/pin", chatStateHandler(dbUtils.pinChat, "Chat pinned successfully"));
 chatsRouter.delete(
   "/:chatId/pin",
-  chatStateHandler(() => dbUtils.unpinChat, "Chat unpinned successfully")
+  chatStateHandler(dbUtils.unpinChat, "Chat unpinned successfully")
 );
 chatsRouter.post(
   "/:chatId/archive",
-  chatStateHandler(() => dbUtils.archiveChat, "Chat archived successfully")
+  chatStateHandler(dbUtils.archiveChat, "Chat archived successfully")
 );
 chatsRouter.delete(
   "/:chatId/archive",
-  chatStateHandler(() => dbUtils.unarchiveChat, "Chat unarchived successfully")
+  chatStateHandler(dbUtils.unarchiveChat, "Chat unarchived successfully")
 );
 
 chatsRouter.get("/:chatId/messages", async (c) => {
   const user = c.get("user");
   const chatId = c.req.param("chatId");
-
-  const chat = dbUtils.getChatByIdAndUser(chatId, user.id);
-  if (!chat) {
-    return c.json({ error: "Chat not found" }, HTTP_STATUS.NOT_FOUND);
-  }
 
   const limit = Math.min(parseInt(c.req.query("limit") || "200", 10), 500);
   const offset = parseInt(c.req.query("offset") || "0", 10);
@@ -269,11 +222,6 @@ chatsRouter.post("/:chatId/messages", async (c) => {
   const chatId = c.req.param("chatId");
   const body = await c.req.json();
   const validated = MessageSchema.parse(body);
-
-  const chat = dbUtils.getChatByIdAndUser(chatId, user.id);
-  if (!chat) {
-    return c.json({ error: "Chat not found" }, HTTP_STATUS.NOT_FOUND);
-  }
 
   const messageId = validated.id || crypto.randomUUID();
   // Validate attachment ownership
@@ -335,11 +283,6 @@ chatsRouter.delete("/:chatId/messages/:messageId", async (c) => {
   const chatId = c.req.param("chatId");
   const messageId = c.req.param("messageId");
 
-  const chat = dbUtils.getChatByIdAndUser(chatId, user.id);
-  if (!chat) {
-    return c.json({ error: "Chat not found" }, HTTP_STATUS.NOT_FOUND);
-  }
-
   const deleted = dbUtils.deleteMessageByUser(messageId, user.id, chatId);
   if (!deleted) {
     return c.json({ error: "Message not found" }, HTTP_STATUS.NOT_FOUND);
@@ -364,7 +307,6 @@ const CompletionRequestSchema = z.object({
       fileIds: z.array(z.string()).optional(),
     })
   ),
-  fileIds: z.array(z.string()).optional(),
   webSearch: z.boolean().optional(),
   memoryEnabled: z.boolean().optional().default(true),
 });
@@ -419,161 +361,6 @@ async function generateChatTitle(userMessage, modelId) {
   }
 }
 
-function inlineTextPart(file, size, text, totalCharCount) {
-  return {
-    type: "text",
-    text: formatInlineAttachmentText({
-      filename: file.filename,
-      mimeType: file.mime_type,
-      size,
-      text,
-      totalCharCount,
-    }),
-  };
-}
-
-async function fileToContentPart(file) {
-  const filePath = path.join(FILE_CONFIG.UPLOAD_DIR, file.stored_filename);
-  if (file.size > MAX_MODEL_ATTACHMENT_BYTES) {
-    throw new Error(`Attachment ${file.filename} exceeds the per-file model limit`);
-  }
-  const fileBuffer = await readFile(filePath).catch((err) => {
-    throw new Error(`Cannot read ${file.id} at ${filePath}: ${err.message}`);
-  });
-
-  switch (getAttachmentCategory(file)) {
-    case FILE_CATEGORIES.IMAGE: {
-      const mediaType = getAttachmentMediaType(file);
-      return {
-        type: "image",
-        image: `data:${mediaType};base64,${fileBuffer.toString("base64")}`,
-      };
-    }
-
-    case FILE_CATEGORIES.OFFICE_MODERN: {
-      let extraction;
-      try {
-        extraction = extractOfficeText({
-          buffer: fileBuffer,
-          filename: file.filename,
-          mimeType: file.mime_type,
-        });
-      } catch (err) {
-        throw new Error(`Office document extraction failed for ${file.filename}: ${err.message}`);
-      }
-      if (!extraction.kind) {
-        throw new AttachmentDenialError(
-          createAttachmentDenial(file, {
-            category: FILE_CATEGORIES.OFFICE_MODERN,
-            code: "ATTACHMENT_UNSUPPORTED",
-            reason: "Office document type could not be determined from filename or MIME type.",
-            suggestion: "Upload a .docx, .xlsx, or .pptx file and try again.",
-          })
-        );
-      }
-      const text = extraction.text;
-      const displayText = text.slice(0, MAX_INLINE_TEXT_ATTACHMENT_CHARS);
-      const truncated = displayText.length < text.length;
-      return inlineTextPart(
-        file,
-        fileBuffer.length,
-        displayText,
-        truncated ? text.length : undefined
-      );
-    }
-
-    case FILE_CATEGORIES.TEXT_LIKE: {
-      const fullText = fileBuffer.toString("utf8");
-      const displayText = fullText.slice(0, MAX_INLINE_TEXT_ATTACHMENT_CHARS);
-      const truncated = displayText.length < fullText.length;
-      return inlineTextPart(
-        file,
-        fileBuffer.length,
-        displayText,
-        truncated ? fullText.length : undefined
-      );
-    }
-
-    default:
-      return {
-        type: "file",
-        data: fileBuffer,
-        mediaType: getAttachmentMediaType(file),
-        filename: file.filename,
-      };
-  }
-}
-
-function applyCacheControl(messages, modelId) {
-  if (!MODEL_FEATURES.SUPPORTS_PROMPT_CACHING(modelId)) {
-    return messages;
-  }
-
-  return messages.map((msg, idx, arr) => {
-    if (msg.role === "system") {
-      return {
-        ...msg,
-        providerOptions: {
-          anthropic: { cacheControl: { type: MODEL_FEATURES.CACHE_TYPE } },
-        },
-      };
-    }
-
-    const isRecentMessage = idx >= arr.length - MODEL_FEATURES.CACHE_LAST_N_MESSAGES;
-    if (isRecentMessage && idx > 0) {
-      return {
-        ...msg,
-        providerOptions: {
-          anthropic: { cacheControl: { type: MODEL_FEATURES.CACHE_TYPE } },
-        },
-      };
-    }
-
-    return msg;
-  });
-}
-
-export async function createMultimodalContent(message, fileIds, filesById) {
-  const content = [];
-  let totalBytes = 0;
-  if (message.content.trim()) {
-    content.push({ type: "text", text: message.content });
-  }
-  for (const id of fileIds) {
-    const file = filesById.get(id);
-    totalBytes += file?.size || 0;
-    if (totalBytes > MAX_MODEL_ATTACHMENT_BYTES) {
-      throw new Error("Combined attachments exceed the model request limit");
-    }
-    content.push(await fileToContentPart(file));
-  }
-  return content;
-}
-
-async function convertToModelMessages(messages, systemPrompt, fileIds = [], filesById = new Map()) {
-  const result = systemPrompt ? [{ role: "system", content: systemPrompt }] : [];
-
-  for (let i = 0; i < messages.length; i++) {
-    const msg = messages[i];
-    if (msg.role === "system") {
-      continue;
-    }
-
-    const isLastUser = i === messages.length - 1 && msg.role === "user";
-    const msgFileIds =
-      msg.fileIds && msg.fileIds.length > 0 ? msg.fileIds : isLastUser ? fileIds : [];
-
-    if (msg.role === "user" && msgFileIds.length > 0) {
-      const content = await createMultimodalContent(msg, msgFileIds, filesById);
-      result.push({ role: msg.role, content });
-    } else {
-      result.push({ role: msg.role, content: msg.content });
-    }
-  }
-
-  return result;
-}
-
 chatsRouter.post(
   "/:chatId/completion",
   createRateLimiter(ENDPOINT_RATE_LIMITS.COMPLETION),
@@ -581,10 +368,6 @@ chatsRouter.post(
     try {
       const user = c.get("user");
       const chatId = c.req.param("chatId");
-      const chat = dbUtils.getChatByIdAndUser(chatId, user.id);
-      if (!chat) {
-        return c.json({ error: "Chat not found" }, HTTP_STATUS.NOT_FOUND);
-      }
 
       const body = await c.req.json();
       const validated = CompletionRequestSchema.parse(body);
@@ -608,12 +391,7 @@ chatsRouter.post(
       const memoryModel = memoryEnabledForRequest ? wrapModelWithMemory(model, dbUtils) : model;
       const systemPrompt = getSystemPrompt(validated.systemPromptId);
 
-      const allFileIds = [
-        ...new Set([
-          ...(validated.fileIds || []),
-          ...validated.messages.flatMap((m) => m.fileIds || []),
-        ]),
-      ];
+      const allFileIds = [...new Set(validated.messages.flatMap((m) => m.fileIds || []))];
 
       const allFiles = allFileIds.length ? dbUtils.getFilesByIdsForUser(allFileIds, user.id) : [];
       if (allFiles.length !== allFileIds.length) {
@@ -641,12 +419,7 @@ chatsRouter.post(
       const filesById = new Map(allFiles.map((f) => [f.id, f]));
 
       const messages = applyCacheControl(
-        await convertToModelMessages(
-          validated.messages,
-          systemPrompt.content,
-          validated.fileIds || [],
-          filesById
-        ),
+        await convertToModelMessages(validated.messages, systemPrompt.content, filesById),
         modelId
       );
 
@@ -732,12 +505,7 @@ chatsRouter.get("/:chatId/stream", async (c) => {
 });
 
 chatsRouter.put("/:chatId/memory", async (c) => {
-  const user = c.get("user");
   const chatId = c.req.param("chatId");
-  const chat = dbUtils.getChatByIdAndUser(chatId, user.id);
-  if (!chat) {
-    return c.json({ error: "Chat not found" }, HTTP_STATUS.NOT_FOUND);
-  }
   const { disabled } = await c.req.json();
   if (typeof disabled !== "boolean") {
     return c.json({ error: "disabled must be a boolean" }, HTTP_STATUS.BAD_REQUEST);

--- a/server/src/routes/images.js
+++ b/server/src/routes/images.js
@@ -83,11 +83,35 @@ imagesRouter.post("/generate", createRateLimiter(ENDPOINT_RATE_LIMITS.IMAGE_GEN)
     );
   }
 
-  const { buffer, mimeType } = await generateImageForProvider(providerName, apiKey, {
-    prompt: prompt.trim(),
-    aspectRatio,
-    model: modelIdentifier,
-  });
+  let generatedImage;
+  try {
+    generatedImage = await generateImageForProvider(providerName, apiKey, {
+      prompt: prompt.trim(),
+      aspectRatio,
+      model: modelIdentifier,
+    });
+  } catch (error) {
+    const message = error?.message || "";
+    const normalizedMessage = message.toLowerCase();
+
+    if (
+      normalizedMessage.includes("invalid api token") ||
+      normalizedMessage.includes("authentication")
+    ) {
+      return c.json({ error: "Invalid API key" }, HTTP_STATUS.UNAUTHORIZED);
+    }
+
+    if (normalizedMessage.includes("rate limit")) {
+      return c.json(
+        { error: "Rate limit exceeded. Please try again later." },
+        HTTP_STATUS.TOO_MANY_REQUESTS
+      );
+    }
+
+    throw error;
+  }
+
+  const { buffer, mimeType } = generatedImage;
 
   const fileId = randomUUID();
   const extension = mimeType === "image/webp" ? "webp" : mimeType.split("/")[1] || "png";

--- a/server/src/routes/images.js
+++ b/server/src/routes/images.js
@@ -40,129 +40,106 @@ async function ensureGeneratedDirectory() {
 }
 
 imagesRouter.post("/generate", createRateLimiter(ENDPOINT_RATE_LIMITS.IMAGE_GEN), async (c) => {
-  try {
-    const user = c.get("user");
-    const body = await c.req.json();
-    const { prompt, aspectRatio = IMAGE_GENERATION.DEFAULT_ASPECT_RATIO, chatId, modelId } = body;
+  const user = c.get("user");
+  const body = await c.req.json();
+  const { prompt, aspectRatio = IMAGE_GENERATION.DEFAULT_ASPECT_RATIO, chatId, modelId } = body;
 
-    if (!prompt || typeof prompt !== "string" || !prompt.trim()) {
-      return c.json({ error: "Prompt is required" }, HTTP_STATUS.BAD_REQUEST);
-    }
+  if (!prompt || typeof prompt !== "string" || !prompt.trim()) {
+    return c.json({ error: "Prompt is required" }, HTTP_STATUS.BAD_REQUEST);
+  }
 
-    if (!IMAGE_GENERATION.ASPECT_RATIOS.includes(aspectRatio)) {
-      return c.json(
-        { error: `Invalid aspect ratio. Allowed: ${IMAGE_GENERATION.ASPECT_RATIOS.join(", ")}` },
-        HTTP_STATUS.BAD_REQUEST
-      );
-    }
-
-    let providerName = "replicate";
-    let apiKey = process.env.REPLICATE_API_KEY;
-    let modelIdentifier = IMAGE_MODELS.DEFAULT;
-    let modelDisplayName = IMAGE_MODELS.DISPLAY_NAME;
-
-    if (modelId) {
-      const model = dbUtils.getEnabledModelWithProvider(modelId);
-      if (model) {
-        providerName = model.provider_name;
-        modelIdentifier = model.model_id;
-        modelDisplayName = model.display_name;
-        if (model.provider_encrypted_key) {
-          apiKey = decryptApiKey(
-            model.provider_encrypted_key,
-            model.provider_iv,
-            model.provider_auth_tag
-          );
-        }
-      }
-    }
-
-    if (!apiKey) {
-      return c.json(
-        { error: "Image generation is not configured. Please add a provider with image models." },
-        HTTP_STATUS.BAD_REQUEST
-      );
-    }
-
-    const { buffer, mimeType } = await generateImageForProvider(providerName, apiKey, {
-      prompt: prompt.trim(),
-      aspectRatio,
-      model: modelIdentifier,
-    });
-
-    // Generate file metadata
-    const fileId = randomUUID();
-    const extension = mimeType === "image/webp" ? "webp" : mimeType.split("/")[1] || "png";
-    const filename = `generated_${Date.now()}.${extension}`;
-    const storedFilename = createStoredFilename(fileId, filename);
-    const filePath = path.join(GENERATED_DIR, storedFilename);
-
-    // Ensure directory exists and save file
-    await ensureGeneratedDirectory();
-    await writeFile(filePath, buffer);
-
-    // Calculate hash and save to database
-    const fileHash = calculateFileHash(buffer);
-    const relativePath = path.join(
-      "server/data/uploads",
-      IMAGE_GENERATION.GENERATED_DIR,
-      storedFilename
-    );
-
-    const fileRecord = dbUtils.createFile(
-      fileId,
-      user.id,
-      filename,
-      storedFilename,
-      relativePath,
-      mimeType,
-      buffer.length,
-      fileHash,
-      {
-        type: "generated",
-        prompt: prompt.trim(),
-        model: modelIdentifier,
-        modelDisplayName,
-        aspectRatio,
-        source: providerName,
-        generatedAt: Date.now(),
-        chatId: chatId || null,
-      }
-    );
-
-    if (!fileRecord) {
-      return c.json({ error: "Failed to save generated image" }, HTTP_STATUS.INTERNAL_SERVER_ERROR);
-    }
-
-    return c.json({
-      id: fileId,
-      filename,
-      size: buffer.length,
-      mimeType,
-      model: modelIdentifier,
-      modelDisplayName,
-      prompt: prompt.trim(),
-      aspectRatio,
-    });
-  } catch (error) {
-    console.error("Image generation error:", error);
-
-    if (error.message?.includes("Invalid API token") || error.message?.includes("authentication")) {
-      return c.json({ error: "Invalid API key" }, HTTP_STATUS.UNAUTHORIZED);
-    }
-
-    if (error.message?.includes("rate limit")) {
-      return c.json(
-        { error: "Rate limit exceeded. Please try again later." },
-        HTTP_STATUS.TOO_MANY_REQUESTS
-      );
-    }
-
+  if (!IMAGE_GENERATION.ASPECT_RATIOS.includes(aspectRatio)) {
     return c.json(
-      { error: error.message || "Image generation failed" },
-      HTTP_STATUS.INTERNAL_SERVER_ERROR
+      { error: `Invalid aspect ratio. Allowed: ${IMAGE_GENERATION.ASPECT_RATIOS.join(", ")}` },
+      HTTP_STATUS.BAD_REQUEST
     );
   }
+
+  let providerName = "replicate";
+  let apiKey = process.env.REPLICATE_API_KEY;
+  let modelIdentifier = IMAGE_MODELS.DEFAULT;
+  let modelDisplayName = IMAGE_MODELS.DISPLAY_NAME;
+
+  if (modelId) {
+    const model = dbUtils.getEnabledModelWithProvider(modelId);
+    if (model) {
+      providerName = model.provider_name;
+      modelIdentifier = model.model_id;
+      modelDisplayName = model.display_name;
+      if (model.provider_encrypted_key) {
+        apiKey = decryptApiKey(
+          model.provider_encrypted_key,
+          model.provider_iv,
+          model.provider_auth_tag
+        );
+      }
+    }
+  }
+
+  if (!apiKey) {
+    return c.json(
+      { error: "Image generation is not configured. Please add a provider with image models." },
+      HTTP_STATUS.BAD_REQUEST
+    );
+  }
+
+  const { buffer, mimeType } = await generateImageForProvider(providerName, apiKey, {
+    prompt: prompt.trim(),
+    aspectRatio,
+    model: modelIdentifier,
+  });
+
+  const fileId = randomUUID();
+  const extension = mimeType === "image/webp" ? "webp" : mimeType.split("/")[1] || "png";
+  const filename = `generated_${Date.now()}.${extension}`;
+  const storedFilename = createStoredFilename(fileId, filename);
+  const filePath = path.join(GENERATED_DIR, storedFilename);
+
+  await ensureGeneratedDirectory();
+  await writeFile(filePath, buffer);
+
+  const fileHash = calculateFileHash(buffer);
+  const relativePath = path.join(
+    "server/data/uploads",
+    IMAGE_GENERATION.GENERATED_DIR,
+    storedFilename
+  );
+
+  const fileRecord = dbUtils.createFile(
+    fileId,
+    user.id,
+    filename,
+    storedFilename,
+    relativePath,
+    mimeType,
+    buffer.length,
+    fileHash,
+    {
+      type: "generated",
+      prompt: prompt.trim(),
+      model: modelIdentifier,
+      modelDisplayName,
+      aspectRatio,
+      source: providerName,
+      generatedAt: Date.now(),
+      chatId: chatId || null,
+    }
+  );
+
+  if (!fileRecord) {
+    return c.json({ error: "Failed to save generated image" }, HTTP_STATUS.INTERNAL_SERVER_ERROR);
+  }
+
+  return c.json({
+    id: fileId,
+    filename,
+    size: buffer.length,
+    mimeType,
+    model: modelIdentifier,
+    modelDisplayName,
+    prompt: prompt.trim(),
+    aspectRatio,
+  });
 });
 
 imagesRouter.get("/status", async (c) => {

--- a/server/src/routes/import.js
+++ b/server/src/routes/import.js
@@ -97,103 +97,67 @@ function buildPreview(conversations) {
 // ============================================================================
 
 importRouter.post("/chatgpt", requireRole("admin", "member"), async (c) => {
-  try {
-    const user = c.get("user");
-    const body = await c.req.json();
+  const user = c.get("user");
+  const body = await c.req.json();
 
-    // Validate request body
-    const bodyValidation = validateRequestBody(body);
-    if (!bodyValidation.valid) {
-      return c.json({ error: bodyValidation.error }, HTTP_STATUS.BAD_REQUEST);
-    }
+  const bodyValidation = validateRequestBody(body);
+  if (!bodyValidation.valid) {
+    return c.json({ error: bodyValidation.error }, HTTP_STATUS.BAD_REQUEST);
+  }
 
-    // Validate and parse export
-    const parseResult = validateAndParseExport(body.data);
-    if (!parseResult.success) {
-      return c.json(
-        { error: "Invalid ChatGPT export format", details: parseResult.errors },
-        HTTP_STATUS.BAD_REQUEST
-      );
-    }
-
-    // Import all conversations atomically
-    const importedChatIds = [];
-    let totalMessages = 0;
-
-    const importAll = db.transaction(() => {
-      for (const conversation of parseResult.conversations) {
-        const { chatId, messageCount } = importConversation(conversation, user.id);
-        importedChatIds.push(chatId);
-        totalMessages += messageCount;
-      }
-    });
-
-    try {
-      importAll();
-    } catch (error) {
-      console.error("[Import] Transaction failed:", error.message);
-      return c.json(
-        { error: "Failed to import conversations", details: error.message },
-        HTTP_STATUS.INTERNAL_SERVER_ERROR
-      );
-    }
-
+  const parseResult = validateAndParseExport(body.data);
+  if (!parseResult.success) {
     return c.json(
-      {
-        success: true,
-        imported: {
-          conversations: importedChatIds.length,
-          messages: totalMessages,
-        },
-        stats: getImportStats(parseResult.conversations),
-        chatIds: importedChatIds,
-      },
-      HTTP_STATUS.CREATED
-    );
-  } catch (error) {
-    console.error("[Import] ChatGPT import failed:", {
-      error: error.message,
-      stack: error.stack,
-    });
-    return c.json(
-      { error: "Failed to import conversations", details: error.message },
-      HTTP_STATUS.INTERNAL_SERVER_ERROR
+      { error: "Invalid ChatGPT export format", details: parseResult.errors },
+      HTTP_STATUS.BAD_REQUEST
     );
   }
+
+  const importedChatIds = [];
+  let totalMessages = 0;
+
+  const importAll = db.transaction(() => {
+    for (const conversation of parseResult.conversations) {
+      const { chatId, messageCount } = importConversation(conversation, user.id);
+      importedChatIds.push(chatId);
+      totalMessages += messageCount;
+    }
+  });
+  importAll();
+
+  return c.json(
+    {
+      success: true,
+      imported: {
+        conversations: importedChatIds.length,
+        messages: totalMessages,
+      },
+      stats: getImportStats(parseResult.conversations),
+      chatIds: importedChatIds,
+    },
+    HTTP_STATUS.CREATED
+  );
 });
 
 importRouter.post("/validate", requireRole("admin", "member"), async (c) => {
-  try {
-    const body = await c.req.json();
+  const body = await c.req.json();
 
-    // Validate request body
-    const bodyValidation = validateRequestBody(body);
-    if (!bodyValidation.valid) {
-      return c.json({ error: bodyValidation.error }, HTTP_STATUS.BAD_REQUEST);
-    }
-
-    // Validate and parse export
-    const parseResult = validateAndParseExport(body.data);
-    if (!parseResult.success) {
-      return c.json({ valid: false, errors: parseResult.errors }, HTTP_STATUS.OK);
-    }
-
-    return c.json({
-      valid: true,
-      conversationCount: parseResult.conversationCount,
-      stats: getImportStats(parseResult.conversations),
-      preview: buildPreview(parseResult.conversations),
-    });
-  } catch (error) {
-    console.error("[Import] Validation failed:", {
-      error: error.message,
-      stack: error.stack,
-    });
-    return c.json(
-      { valid: false, errors: ["Failed to validate file: " + error.message] },
-      HTTP_STATUS.INTERNAL_SERVER_ERROR
-    );
+  const bodyValidation = validateRequestBody(body);
+  if (!bodyValidation.valid) {
+    return c.json({ error: bodyValidation.error }, HTTP_STATUS.BAD_REQUEST);
   }
+
+  const parseResult = validateAndParseExport(body.data);
+  if (!parseResult.success) {
+    return c.json({ valid: false, errors: parseResult.errors }, HTTP_STATUS.OK);
+  }
+
+  return c.json({
+    valid: true,
+    conversationCount: parseResult.conversationCount,
+    stats: getImportStats(parseResult.conversations),
+    preview: buildPreview(parseResult.conversations),
+  });
 });
 
 importRouter.get("/formats", async (c) => {

--- a/server/src/routes/memory.js
+++ b/server/src/routes/memory.js
@@ -9,7 +9,7 @@ memoryRouter.use("/*", ensureSession);
 
 memoryRouter.get("/status", async (c) => {
   const user = c.get("user");
-  const globalEnabled = dbUtils.getMemoryGlobalEnabled() === "true";
+  const globalEnabled = dbUtils.getSetting("memory_enabled") === "true";
   const enabled = dbUtils.getUserMemoryEnabled(user.id);
   const memoriesCount = dbUtils.getMemoriesCount(user.id);
   return c.json({ enabled, globalEnabled, memoriesCount });

--- a/server/src/routes/settings.js
+++ b/server/src/routes/settings.js
@@ -59,20 +59,24 @@ settingsRouter.put("/web-search", ensureSession, requireRole("admin"), async (c)
 // ========================================
 
 settingsRouter.get("/memory", ensureSession, requireRole("admin"), async (c) => {
-  const globalEnabled = dbUtils.getMemoryGlobalEnabled() === "true";
-  const extractionModel = dbUtils.getMemoryExtractionModel();
+  const globalEnabled = dbUtils.getSetting("memory_enabled") === "true";
+  const extractionModel = dbUtils.getSetting("memory_extraction_model");
   return c.json({ globalEnabled, extractionModel });
 });
 
 settingsRouter.put("/memory", ensureSession, requireRole("admin"), async (c) => {
   const body = await c.req.json();
   if (typeof body.globalEnabled === "boolean") {
-    dbUtils.setMemoryGlobalEnabled(body.globalEnabled);
+    dbUtils.setSetting("memory_enabled", body.globalEnabled ? "true" : "false");
   }
   if (body.extractionModel !== undefined) {
-    dbUtils.setMemoryExtractionModel(body.extractionModel || null);
+    if (body.extractionModel) {
+      dbUtils.setSetting("memory_extraction_model", body.extractionModel);
+    } else {
+      dbUtils.deleteSetting("memory_extraction_model");
+    }
   }
-  const globalEnabled = dbUtils.getMemoryGlobalEnabled() === "true";
-  const extractionModel = dbUtils.getMemoryExtractionModel();
+  const globalEnabled = dbUtils.getSetting("memory_enabled") === "true";
+  const extractionModel = dbUtils.getSetting("memory_extraction_model");
   return c.json({ globalEnabled, extractionModel });
 });

--- a/server/src/test/appMiddleware.test.js
+++ b/server/src/test/appMiddleware.test.js
@@ -44,6 +44,8 @@ describe("app middleware", () => {
   describe("body size limit", () => {
     test("rejects request with Content-Length over 50MB", async () => {
       const res = await app.request("/api/auth/session", {
+        method: "POST",
+        body: "x",
         headers: { "content-length": String(60 * 1024 * 1024) },
       });
       expect(res.status).toBe(413);

--- a/server/src/test/chats.test.js
+++ b/server/src/test/chats.test.js
@@ -7,7 +7,7 @@ import {
   makeRequest,
 } from "./helpers.js";
 import { dbUtils } from "../lib/db.js";
-import { createMultimodalContent } from "../routes/chats.js";
+import { createMultimodalContent } from "../lib/completion.js";
 import { unlink } from "fs/promises";
 import path from "path";
 import { FILE_CONFIG } from "../lib/fileUtils.js";
@@ -410,7 +410,11 @@ describe("chat routes", () => {
 
       let threw = false;
       try {
-        await createMultimodalContent({ content: "hello" }, [fileId], adminUser.id);
+        await createMultimodalContent(
+          { content: "hello" },
+          [fileId],
+          new Map([[fileId, dbUtils.getFileById(fileId)]])
+        );
       } catch {
         threw = true;
       }

--- a/server/src/test/db.message-files.test.js
+++ b/server/src/test/db.message-files.test.js
@@ -80,6 +80,44 @@ function messageFilesData(database) {
     .all();
 }
 
+function attachFileIds(messages) {
+  if (!messages.length) {
+    return messages;
+  }
+  const placeholders = messages.map(() => "?").join(",");
+  const rows = db
+    .prepare(
+      `SELECT message_id, file_id FROM message_files WHERE message_id IN (${placeholders}) ORDER BY created_at ASC, rowid ASC`
+    )
+    .all(...messages.map((m) => m.id));
+  const fileIdsByMessage = {};
+  for (const row of rows) {
+    fileIdsByMessage[row.message_id] ??= [];
+    fileIdsByMessage[row.message_id].push(row.file_id);
+  }
+  return messages.map((message) => ({
+    ...message,
+    file_ids: fileIdsByMessage[message.id] ?? null,
+  }));
+}
+
+function selectMessageWithFileIds(messageId) {
+  const message = db.prepare("SELECT * FROM messages WHERE id = ?").get(messageId);
+  return message ? attachFileIds([message])[0] : null;
+}
+
+function selectMessagesWithFileIdsForChat(chatId, userId) {
+  const messages = db
+    .prepare("SELECT * FROM messages WHERE chat_id = ? AND user_id = ? ORDER BY created_at ASC")
+    .all(chatId, userId);
+  return attachFileIds(messages);
+}
+
+function deleteMessageRow(messageId) {
+  const result = db.prepare("DELETE FROM messages WHERE id = ?").run(messageId);
+  return result.changes > 0;
+}
+
 describe("message_files junction table", () => {
   let app, adminCookie, adminUserId, chatId, fileId1, fileId2;
 
@@ -180,7 +218,7 @@ describe("message_files junction table", () => {
     }).toThrow();
   });
 
-  test("getMessageById returns fileIds in insertion order when timestamps match", async () => {
+  test("message fileIds preserve insertion order when timestamps match", async () => {
     const firstFile = await createTestFile(adminUserId, "ordered-first.txt");
     const secondFile = await createTestFile(adminUserId, "ordered-second.txt");
     const res = await makeRequest(app, "POST", `/api/chats/${chatId}/messages`, {
@@ -194,7 +232,7 @@ describe("message_files junction table", () => {
 
     expect(res.status).toBe(201);
     const msg = await res.json();
-    const dbMsg = dbUtils.getMessageById(msg.id);
+    const dbMsg = selectMessageWithFileIds(msg.id);
     expect(dbMsg.file_ids).toEqual([secondFile, firstFile]);
   });
 
@@ -219,7 +257,7 @@ describe("message_files junction table", () => {
     expect(row.count).toBe(0);
   });
 
-  test("getMessageById returns fileIds from junction table", async () => {
+  test("message fileIds are read from junction table", async () => {
     // Create a message with files
     const msgRes = await makeRequest(app, "POST", `/api/chats/${chatId}/messages`, {
       body: {
@@ -232,7 +270,7 @@ describe("message_files junction table", () => {
     const msg = await msgRes.json();
 
     // Get message by ID
-    const dbMsg = dbUtils.getMessageById(msg.id);
+    const dbMsg = selectMessageWithFileIds(msg.id);
     expect(dbMsg.file_ids).toEqual([fileId1]);
   });
 
@@ -259,7 +297,7 @@ describe("message_files junction table", () => {
     const msg2 = await msg2Res.json();
 
     // Get all messages for chat
-    const dbMessages = dbUtils.getMessagesByChatAndUser(chatId, adminUserId);
+    const dbMessages = selectMessagesWithFileIdsForChat(chatId, adminUserId);
 
     const msgById = {};
     for (const m of dbMessages) {
@@ -332,7 +370,7 @@ describe("message_files junction table", () => {
     expect(row.count).toBe(2);
 
     // Delete the message
-    const deleted = dbUtils.deleteMessage(msg.id);
+    const deleted = deleteMessageRow(msg.id);
     expect(deleted).toBe(true);
 
     // All junction entries should be gone (CASCADE)
@@ -341,7 +379,7 @@ describe("message_files junction table", () => {
     expect(row.count).toBe(0);
   });
 
-  test("getMessagesByChatAndUser returns fileIds from junction table", async () => {
+  test("chat/user message query returns fileIds from junction table", async () => {
     // Create a new chat for this specific test to avoid conflicts
     const chatRes = await makeRequest(app, "POST", "/api/chats", {
       body: { title: "Get messages by user test" },
@@ -365,7 +403,7 @@ describe("message_files junction table", () => {
     const msg1 = await msg1Res.json();
 
     // Get messages by chat and user
-    const dbMessages = dbUtils.getMessagesByChatAndUser(testChatId, adminUserId);
+    const dbMessages = selectMessagesWithFileIdsForChat(testChatId, adminUserId);
 
     expect(dbMessages.length).toBe(1);
     expect(dbMessages[0].file_ids).toEqual([freshFile]);
@@ -427,7 +465,7 @@ describe("message_files junction table", () => {
     expect(deletedFile).toBe(true);
 
     // Verify message still exists
-    const dbMsg = dbUtils.getMessageById(msg.id);
+    const dbMsg = selectMessageWithFileIds(msg.id);
     expect(dbMsg).not.toBeNull();
     expect(dbMsg.file_ids).toEqual([fileToKeep]); // Only the remaining file
 
@@ -437,7 +475,7 @@ describe("message_files junction table", () => {
     expect(row.count).toBe(1);
   });
 
-  test("deleteMessage cascades - junction rows gone, file remains", async () => {
+  test("deleting a message cascades - junction rows gone, file remains", async () => {
     // Create a new chat for this specific test
     const chatRes = await makeRequest(app, "POST", "/api/chats", {
       body: { title: "Message delete cascade test" },
@@ -470,7 +508,7 @@ describe("message_files junction table", () => {
     expect(dbFile).not.toBeNull();
 
     // Delete the message (this should cascade to junction table)
-    const deletedMsg = dbUtils.deleteMessage(msg.id);
+    const deletedMsg = deleteMessageRow(msg.id);
     expect(deletedMsg).toBe(true);
 
     // Verify file still exists

--- a/server/src/test/helpers.js
+++ b/server/src/test/helpers.js
@@ -1,95 +1,13 @@
-import { Hono } from "hono";
-import { bodyLimit } from "hono/body-limit";
-import { cors } from "hono/cors";
 import db, { dbUtils } from "../lib/db.js";
+import { createApp } from "../app.js";
 
 // Re-export db for tests that need direct database access
 export { db };
 import { hashPassword } from "../lib/security.js";
-import { authRouter, _resetRateLimits } from "../routes/auth.js";
-import { chatsRouter } from "../routes/chats.js";
-import { adminRouter } from "../routes/admin.js";
-import { providersRouter } from "../routes/providers.js";
-import { filesRouter } from "../routes/files.js";
-import { foldersRouter } from "../routes/folders.js";
-import { settingsRouter } from "../routes/settings.js";
-import { modelsRouter } from "../routes/models.js";
-import { importRouter } from "../routes/import.js";
-import { imagesRouter } from "../routes/images.js";
-import { versionRouter } from "../routes/version.js";
-import { memoryRouter } from "../routes/memory.js";
-import { securityHeaders } from "../middleware/securityHeaders.js";
-import { installRouteErrorHandler } from "../lib/errorHandler.js";
+import { _resetRateLimits } from "../routes/auth.js";
 
 export function createTestApp() {
-  const app = new Hono();
-
-  installRouteErrorHandler(app);
-  [
-    authRouter,
-    adminRouter,
-    providersRouter,
-    modelsRouter,
-    filesRouter,
-    chatsRouter,
-    settingsRouter,
-    versionRouter,
-    imagesRouter,
-    importRouter,
-    foldersRouter,
-    memoryRouter,
-  ].forEach(installRouteErrorHandler);
-
-  app.use("*", securityHeaders());
-
-  app.use("/api/*", async (c, next) => {
-    const contentLength = parseInt(c.req.header("content-length") || "0", 10);
-    if (contentLength > 50 * 1024 * 1024) {
-      return c.json({ error: "Request body too large" }, 413);
-    }
-    await next();
-  });
-
-  app.use(
-    "/api/*",
-    bodyLimit({
-      maxSize: 50 * 1024 * 1024,
-      onError: (c) => c.json({ error: "Request body too large" }, 413),
-    })
-  );
-
-  app.use(
-    "/api/*",
-    cors({
-      origin: (origin) => {
-        if (!origin) {
-          return null;
-        }
-        try {
-          const url = new URL(origin);
-          return url.hostname === "localhost" || url.hostname === "127.0.0.1" ? origin : null;
-        } catch {
-          return null;
-        }
-      },
-      credentials: true,
-    })
-  );
-
-  app.route("/api/auth", authRouter);
-  app.route("/api/admin", adminRouter);
-  app.route("/api/admin/providers", providersRouter);
-  app.route("/api", modelsRouter);
-  app.route("/api/files", filesRouter);
-  app.route("/api/chats", chatsRouter);
-  app.route("/api/settings", settingsRouter);
-  app.route("/api/version", versionRouter);
-  app.route("/api/images", imagesRouter);
-  app.route("/api/import", importRouter);
-  app.route("/api/folders", foldersRouter);
-  app.route("/api/memory", memoryRouter);
-
-  return app;
+  return createApp();
 }
 
 export function resetDatabase() {

--- a/server/src/test/images.test.js
+++ b/server/src/test/images.test.js
@@ -1,0 +1,92 @@
+import { describe, test, expect, beforeEach, afterAll, mock } from "bun:test";
+
+let generateImageForProviderImpl = async () => ({
+  buffer: Buffer.from("image"),
+  mimeType: "image/png",
+});
+
+mock.module("../lib/imageProviderFactory.js", () => ({
+  generateImageForProvider: (...args) => generateImageForProviderImpl(...args),
+}));
+
+const { createTestApp, resetDatabase, seedAdminUser, makeRequest } = await import("./helpers.js");
+
+const originalReplicateApiKey = process.env.REPLICATE_API_KEY;
+
+describe("image routes", () => {
+  let app, adminCookie;
+
+  beforeEach(async () => {
+    resetDatabase();
+    process.env.REPLICATE_API_KEY = "test-replicate-key";
+    generateImageForProviderImpl = async () => ({
+      buffer: Buffer.from("image"),
+      mimeType: "image/png",
+    });
+
+    app = createTestApp();
+    const admin = await seedAdminUser(app);
+    adminCookie = admin.cookie;
+  });
+
+  afterAll(() => {
+    if (originalReplicateApiKey === undefined) {
+      delete process.env.REPLICATE_API_KEY;
+    } else {
+      process.env.REPLICATE_API_KEY = originalReplicateApiKey;
+    }
+  });
+
+  test("POST /api/images/generate maps invalid provider tokens to 401", async () => {
+    generateImageForProviderImpl = async () => {
+      throw new Error("Invalid API token: test secret should not leak");
+    };
+
+    const res = await makeRequest(app, "POST", "/api/images/generate", {
+      body: { prompt: "draw a cube" },
+      cookie: adminCookie,
+    });
+
+    expect(res.status).toBe(401);
+    expect(await res.json()).toEqual({ error: "Invalid API key" });
+  });
+
+  test("POST /api/images/generate maps provider rate limits to 429", async () => {
+    generateImageForProviderImpl = async () => {
+      throw new Error("provider rate limit reached");
+    };
+
+    const res = await makeRequest(app, "POST", "/api/images/generate", {
+      body: { prompt: "draw a cube" },
+      cookie: adminCookie,
+    });
+
+    expect(res.status).toBe(429);
+    expect(await res.json()).toEqual({
+      error: "Rate limit exceeded. Please try again later.",
+    });
+  });
+
+  test("POST /api/images/generate leaves unrelated provider errors generic", async () => {
+    generateImageForProviderImpl = async () => {
+      throw new Error("sensitive internal provider trace");
+    };
+
+    const originalConsoleError = console.error;
+    console.error = () => {};
+    let res;
+    try {
+      res = await makeRequest(app, "POST", "/api/images/generate", {
+        body: { prompt: "draw a cube" },
+        cookie: adminCookie,
+      });
+    } finally {
+      console.error = originalConsoleError;
+    }
+
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body).toEqual({ error: "Internal server error" });
+    expect(JSON.stringify(body)).not.toContain("sensitive internal provider trace");
+  });
+});

--- a/server/src/test/memory.test.js
+++ b/server/src/test/memory.test.js
@@ -5,7 +5,7 @@ import { MEMORY_EXTRACTION_MAX_FACTS_PER_TURN } from "@faster-chat/shared";
 describe("memory helpers", () => {
   test("isMemoryEnabledForRequest requires all memory gates to pass", () => {
     const dbUtils = {
-      getMemoryGlobalEnabled: () => "true",
+      getSetting: () => "true",
       getUserMemoryEnabled: () => true,
       getChatMemoryDisabled: () => false,
     };
@@ -18,7 +18,7 @@ describe("memory helpers", () => {
     ).toBe(false);
     expect(
       isMemoryEnabledForRequest({
-        dbUtils: { ...dbUtils, getMemoryGlobalEnabled: () => "false" },
+        dbUtils: { ...dbUtils, getSetting: () => "false" },
         userId: 1,
         chatId: "chat-1",
         requestEnabled: true,
@@ -44,7 +44,7 @@ describe("memory helpers", () => {
 
   test("memory middleware reads request metadata from providerOptions", async () => {
     const middleware = createMemoryMiddleware({
-      getMemoryGlobalEnabled: () => "true",
+      getSetting: () => "true",
       getUserMemoryEnabled: () => true,
       getChatMemoryDisabled: () => false,
       getMemoriesForUser: () => [{ fact: "uses Arch Linux" }],
@@ -96,7 +96,7 @@ describe("memory helpers", () => {
 
   test("memory middleware skips injection when the request disables memory", async () => {
     const middleware = createMemoryMiddleware({
-      getMemoryGlobalEnabled: () => "true",
+      getSetting: () => "true",
       getUserMemoryEnabled: () => true,
       getChatMemoryDisabled: () => false,
       getMemoriesForUser: () => [{ fact: "prefers Python" }],


### PR DESCRIPTION
Fixes M5–M9 + nine server minors from CODE-QUALITY-REVIEW.md (spec: specs/quality-review/spec-6-db-routes-structure.md). Net **−265 lines** in server/src.

- **M5**: memory-settings wrappers deleted — they only resolved via the `Object.assign` flat-merge; callers use `getSetting("memory_enabled") === "true"` directly.
- **M6**: dead unscoped DB twins deleted (`softDeleteChat`, `hardDeleteChat`, `getMessageById`, `deleteMessage`, `getFilesByIds`, non-paginated `getChatsByUserId`, `getMessagesByChatAndUser`); `deleteFile`/`updateFileMetadata` kept — they gained production callers in #19/#24. Tests query `db` directly.
- **M7**: chat ownership middleware (`use("/:chatId")` + `use("/:chatId/*")`, user-scoped load, 404 on miss, `c.set("chat")`) replaces 7 copy-pasted checks. Reviewer-enumerated all 12 sub-routes for coverage. Side effect: `GET /:chatId/stream` tightened from 204 to 404 for nonexistent/other-user chats.
- **M8**: completion API's dual fileIds channel collapsed — top-level field, server `isLastUser` fallback, and frontend transport copy all deleted; per-message fileIds only (regenerate verified to still attach files).
- **M9**: `createApp()` extracted to `server/src/app.js`, shared by `index.js` and test helpers — kills the line-for-line duplicated assembly whose CORS had already diverged; production CORS wins.
- Minors: completion pipeline (~175 lines) moved to `lib/completion.js`; `chatStateHandler` thunk ceremony removed; db.js single-consumer helpers and fake-DI globals moved to consumers; **one** parent `onError` (was 13 installs); **one** body cap (hono `bodyLimit`, hoisted constant); unused `DISABLE_RATE_LIMIT` seam deleted; dead API removed (`middleware.stop`, `stopModelsDevTimers`); import/images routes migrated to the global error handler — no raw `error.message` to clients; `validatePublicFetchUrl` unified with provider prefix checks.
- From adversarial review: image `/generate` keeps its curated 401 (invalid key) / 429 (rate limit) mappings via a narrow local catch — the migration had flattened them to generic 500s.

Tests: server 420 pass (baseline 417 + 3 provider-error-mapping tests), frontend 36 pass.

Adversarial review: opus REQUEST-CHANGES + gpt-5.5 REQUEST-CHANGES (both converged on the single image-route regression) → fixed with tests; all other probes cleared (middleware coverage, error bubbling, fileIds contract, CORS parity, deleted-symbol greps).