### PR TITLE
fix: readable error when backend returns non-JSON failure

### DIFF
--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -12,13 +12,12 @@ export async function apiFetch(endpoint, options = {}) {
     },
   });
 
-  const data = await response.json();
-
   if (!response.ok) {
-    const error = new Error(data.error || "Request failed");
+    const data = await response.json().catch(() => null);
+    const error = new Error(data?.error || `Server unreachable (${response.status})`);
     error.status = response.status;
     throw error;
   }
 
-  return data;
+  return response.json();
 }

--- a/frontend/src/lib/api.test.js
+++ b/frontend/src/lib/api.test.js
@@ -1,0 +1,41 @@
+import { describe, test, expect, vi, afterEach } from "vitest";
+import { apiFetch } from "./api";
+
+function mockFetch(response) {
+  vi.stubGlobal("fetch", vi.fn().mockResolvedValue(response));
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("apiFetch", () => {
+  test("returns parsed JSON on success", async () => {
+    mockFetch(new Response(JSON.stringify({ ok: true }), { status: 200 }));
+    expect(await apiFetch("/api/version")).toEqual({ ok: true });
+  });
+
+  test("throws the server's error message on JSON error responses", async () => {
+    mockFetch(new Response(JSON.stringify({ error: "Chat not found" }), { status: 404 }));
+    await expect(apiFetch("/api/chats/x")).rejects.toMatchObject({
+      message: "Chat not found",
+      status: 404,
+    });
+  });
+
+  test("throws a readable message when the backend is down (non-JSON body)", async () => {
+    mockFetch(new Response("<html>502 Bad Gateway</html>", { status: 502 }));
+    await expect(apiFetch("/api/version")).rejects.toMatchObject({
+      message: "Server unreachable (502)",
+      status: 502,
+    });
+  });
+
+  test("throws a readable message on an empty error body", async () => {
+    mockFetch(new Response(null, { status: 503 }));
+    await expect(apiFetch("/api/version")).rejects.toMatchObject({
+      message: "Server unreachable (503)",
+      status: 503,
+    });
+  });
+});


### PR DESCRIPTION
`apiFetch` called `response.json()` before checking `response.ok`, so a dead backend (proxy 502 HTML page, empty 503 body) surfaced as a raw JSON parse error instead of anything actionable.

Now: success path parses as before; failure path tries JSON and uses the server's `{error}` when present, otherwise throws `Server unreachable (<status>)` with `status` attached.

Tests: 4 new unit tests (success, JSON error passthrough, HTML 502, empty 503). Frontend suite 40 pass.